### PR TITLE
変数名とDBカラム名のリファクタリング close #6

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -72,21 +72,21 @@ public class WordController {
 	//DB新規登録
 	@PostMapping("/regist")
 	public String regist(WordForm wordForm, Model model) {
-		System.out.println("受け取ったcategoryId = " + wordForm.getCategoryId());
+//		System.out.println("受け取ったcategoryId = " + wordForm.getCategoryId());
 		Optional<Category> categoryOpt = categoryService.findByCategoryId(wordForm.getCategoryId());
 		if (categoryOpt.isEmpty()) {
 			return "regist_error";
 		}
-		Optional<Word> wordOpt = wordService.findByName(wordForm.getWord());
+		Optional<Word> wordOpt = wordService.findByWordName(wordForm.getWordName());
 		if (wordOpt.isPresent()) {
 			model.addAttribute("word",wordOpt.get());
 			model.addAttribute("categories", categoryService.findAll());
 			return "regist_cancel_or_edit";
-		} else {
-			model.addAttribute("regist_ok", "登録完了しました");
-			model.addAttribute("wordList", wordService.findAll());
-			return "word_list";
 		}
+		wordService.addWord(wordForm);
+		model.addAttribute("regist_ok", "登録完了しました");
+		model.addAttribute("wordList", wordService.findAll());
+		return "word_list";
 	}
 
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -62,7 +62,7 @@ public class WordDetailController {
 		Word word = wordOpt.get();
 		// 編集用wordFormに、DBから検索したwordの値をセット
 		WordForm wordForm = new WordForm();
-		wordForm.setWord(word.getName());
+		wordForm.setWordName(word.getWordName());
 		wordForm.setContent(word.getContent());
 		wordForm.setCategoryId(word.getCategory().getId());
 		wordForm.setCategoryName(word.getCategory().getName());	

--- a/KnowledgeMap/src/main/java/com/example/demo/entity/Word.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/entity/Word.java
@@ -13,8 +13,6 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import com.example.demo.entity.Category;
-
 import lombok.Data;
 
 /*
@@ -31,8 +29,8 @@ public class Word {
 	@Column(name="id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id;
-	@Column(name="word")
-	private String name;
+	@Column(name="word_name")
+	private String wordName;
 	@Column(name="content")
 	private String content;
     @ManyToOne

--- a/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
@@ -10,7 +10,7 @@ import lombok.Data;
 @Data
 public class WordForm {
 	@NotBlank(message="wordが空です")
-    private String word;
+    private String wordName;
 	@NotBlank(message="contentが空です")
     private String content;
 	@NotNull(message="categoryが選択されていません")

--- a/KnowledgeMap/src/main/java/com/example/demo/repository/WordRepository.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/repository/WordRepository.java
@@ -10,7 +10,7 @@ import com.example.demo.entity.Word;
 public interface WordRepository extends JpaRepository<Word, Integer> {
     public List<Word> findByCategoryId(Integer categoryId);
 //    public void deleteById(Integer id);
-    public Optional<Word> findByName(String name);
+    public Optional<Word> findByWordName(String name);
     
 }
 

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
@@ -7,7 +7,7 @@ import com.example.demo.entity.Word;
 import com.example.demo.form.WordForm;
 
 public interface WordService {
-	public Optional<Word> findByName(String name);
+	public Optional<Word> findByWordName(String name);
 	public void addWord(WordForm wordForm);
     public List<Word> findAll();
     public Optional<Word> findById(Integer id);

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceimpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceimpl.java
@@ -20,14 +20,14 @@ public class WordServiceimpl implements WordService{
 	
 	// nameで検索
 	@Override
-	public Optional<Word> findByName(String name) {
-		return wordRepository.findByName(name);
+	public Optional<Word> findByWordName(String name) {
+		return wordRepository.findByWordName(name);
 	}
 	
 	@Override
 	public void addWord(WordForm wordForm) {
 		Word word = new Word();	
-		word.setName(wordForm.getWord());
+		word.setWordName(wordForm.getWordName());
 		word.setContent(wordForm.getContent());
 		// wordForm型の の categoryId から Category型に変換して Word型にセット
 		Optional<Category> categoryOpt =  categoryRepository.findById(wordForm.getCategoryId()); 
@@ -62,7 +62,7 @@ public class WordServiceimpl implements WordService{
 	public void updateWord(Integer id, WordForm wordForm) {
 		Optional<Word> wordOpt = wordRepository.findById(id);
 		Word word = wordOpt.get();		
-		word.setName(wordForm.getWord());
+		word.setWordName(wordForm.getWordName());
 		word.setContent(wordForm.getContent());	
 		// wordForm型の の categoryId から Category型に変換して Word型にセット
 		Optional<Category> categoryOpt =  categoryRepository.findById(wordForm.getCategoryId()); 

--- a/KnowledgeMap/src/main/resources/templates/edit_word.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_word.html
@@ -11,8 +11,8 @@
 	        <tr>
 	            <th>word</th>
 	            <td>
-	                <input type="text" th:field="*{word}">
-					<span th:errors="*{word}"></span>
+	                <input type="text" th:field="*{wordName}">
+					<span th:errors="*{wordName}"></span>
 	            </td>
 	        </tr>
 	        <tr>              

--- a/KnowledgeMap/src/main/resources/templates/regist_cancel_or_edit.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_cancel_or_edit.html
@@ -6,15 +6,15 @@
 </head>
 <body>
 	<h1>登録確認</h1>
-	<p><span th:text="${word.name}"></span>はすでに登録されています。</p>
+	<p><span th:text="${word.wordName}"></span>はすでに登録されています。</p>
 	    <table th:object="${word}">
 	        <tr>
 	            <th>word</th>
-	            <td th:text="*{name}"></td>
+	            <td th:text="*{wordName}"></td>
 	        </tr>
 	        <tr>              
 	            <th>content</th>
-	            <td th:text="*{name}"></td>
+	            <td th:text="*{content}"></td>
 	        </tr>
 	        <tr>
 	            <th>category</th>

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -11,8 +11,8 @@
             <tr>
                 <th>word</th>
                 <td>
-					<span th:text="*{word}"></span>
-					<input type="hidden" th:field="*{word}">					
+					<span th:text="*{wordName}"></span>
+					<input type="hidden" th:field="*{wordName}">					
 				</td>
             </tr>
             <tr>

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -11,8 +11,8 @@
             <tr>
                 <th>word</th>
                 <td>
-                    <input type="text" th:field="*{word}">
-					<span th:errors="*{word}"></span>
+                    <input type="text" th:field="*{wordName}">
+					<span th:errors="*{wordName}"></span>
                 </td>
             </tr>
             <tr>              

--- a/KnowledgeMap/src/main/resources/templates/word_detail.html
+++ b/KnowledgeMap/src/main/resources/templates/word_detail.html
@@ -13,7 +13,7 @@
         </section>
         <section>
             <h2>name</h2>
-            <p th:text="*{name}"></p>
+            <p th:text="*{wordName}"></p>
         </section>
         <section>
             <h2>content</h2>

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -13,7 +13,7 @@
     <ul>
         <li th:each="word : ${wordList}">
 			<a th:href="@{/wordDetail/{id}(id=${word.id})}" 
-			   th:text="${word.name}"></a>
+			   th:text="${word.wordName}"></a>
 		</li>
     </ul>
 </body>


### PR DESCRIPTION
WordエンティティクラスのnameをwordNameに
WordFormクラスのwordをwordNameに
wordテーブルのwordカラム名をword_nameに
変更しました。

また、issue#5(新規登録の際にDB問い合わせ)の変更時に
wordControllerの中でaddWordメソッドが抜けていたので追加。
