### PR TITLE
word新規登録時、ユーザーがカテゴリーを新規作成できるように変更 close #10

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
@@ -2,8 +2,8 @@ package com.example.demo.form;
 
 import java.util.List;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import lombok.Data;
 
@@ -13,10 +13,14 @@ public class WordForm {
     private String wordName;
 	@NotBlank(message="contentが空です")
     private String content;
-	@NotNull(message="categoryが選択されていません")
+	//@NotNull(message="categoryが選択されていません")
     private Integer categoryId;                // カテゴリ選択用
 	
 	private String categoryName;
     private List<Long> relatedWordIds;      // 関連語（複数選択）
-
+    
+    @AssertTrue(message="categoryが選択されていません")
+    public boolean isCategoryNotNull() {
+    	return categoryId != null || (categoryName != null && !categoryName.isBlank());
+    }
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/repository/CategoryRepository.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/repository/CategoryRepository.java
@@ -1,9 +1,12 @@
 package com.example.demo.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.demo.entity.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Integer> {
+	public Optional<Category> findByName(String name);
 }
 

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
@@ -8,4 +8,6 @@ import com.example.demo.entity.Category;
 public interface CategoryService {
 	public List<Category> findAll();
 	public Optional<Category> findByCategoryId(Integer categoryId);
+	public Integer addCategory(String categoryName);
+	public Optional<Category> searchByName(String categoryName);
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
@@ -22,5 +22,18 @@ public class CategoryServiceImpl implements CategoryService {
 		Optional<Category>  categoryOpt = categoryRepository.findById(categoryId);
 		return categoryOpt;
 	}
+	//nameで検索
+	@Override
+	public Optional<Category> searchByName(String categoryName) {
+		return categoryRepository.findByName(categoryName);
+	}
+	//nameで登録してそのidを返す
+	@Override
+	public Integer addCategory(String categoryName) {
+		Category category = new Category();
+		category.setName(categoryName);
+		categoryRepository.save(category);
+		return category.getId();
+	}
 
 }

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -1,43 +1,45 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
 <head>
-<meta charset="UTF-8">
-<title>単語の登録</title>
+	<meta charset="UTF-8">
+	<title>単語の登録</title>
 </head>
+
 <body>
-    <h1>新規登録</h1>
-    <form th:action="@{/registConfirm}" method="post">
-        <table th:object="${wordForm}">
-            <tr>
-                <th>word</th>
-                <td>
-                    <input type="text" th:field="*{wordName}">
+	<h1>新規登録</h1>
+	<form th:action="@{/registConfirm}" method="post">
+		<table th:object="${wordForm}" border="1">
+			<tr>
+				<th>word</th>
+				<td>
+					<input type="text" th:field="*{wordName}">
 					<span th:errors="*{wordName}"></span>
-                </td>
-            </tr>
-            <tr>              
-                <th>content</th>
-                <td>
-                    <textarea th:field="*{content}"></textarea>
+				</td>
+			</tr>
+			<tr>
+				<th>content</th>
+				<td>
+					<textarea th:field="*{content}"></textarea>
 					<span th:errors="*{content}"></span>
-                </td>
-            </tr>
-            <tr>
-                <th>category</th>
-                <td>
-                    <select th:field="*{categoryId}" required>
-                        <option value="">カテゴリを選択</option>
-                        <option th:each="category : ${categories}" 
-								th:value="${category.id}"
-								th:text="${category.name}">
-						</option>						
-                    </select>
-					<span th:errors="*{categoryId}"></span>
-                </td>
-            </tr>               
-        </table>
-        <button>登録内容の確認</button>	
-    </form>
+				</td>
+			</tr>
+			<tr>
+				<th>category</th>
+				<td>
+					<select th:field="*{categoryId}">
+						<option value="">カテゴリを選択</option>
+						<option th:each="category : ${categories}" th:value="${category.id}" th:text="${category.name}">
+						</option>
+					</select>
+					<p>または新しいカテゴリーをつくる<input type="text" th:field="*{categoryName}"></p>
+					<span th:errors="*{categoryNotNull}"></span>
+				</td>
+			</tr>
+		</table>
+		<button>登録内容の確認</button>
+	</form>
 	<a th:href="@{/wordList}">一覧へ戻る</a>
 </body>
+
 </html>


### PR DESCRIPTION
word新規登録時、selectタグから既存のcategoryを選択するのに加えて、
ユーザがinputタグに入力したcategoryNameをcategoryテーブルに新規登録できる機能を追加。

それに伴い、WordFormクラスのcategoryのバリデーションチェックを、
@NotNullから@AssertTrueによるチェックに変更
（categoryIdとcategoryNameの両方がnullの場合のみバリデーションエラー発生）

入力されたcategoryNameの値がすでにcategoryテーブルに存在するかどうかチェックし、
存在する場合はcategoryNameから検索したcategoryIdを使用してwordを新規登録する。

selectタグからcategoryId、inputタグからcategoryName、この両方を受け取ってしまった場合は
categoryNameが優先されて登録となるのが現状。要検討。
