### PR TITLE
新規登録の際、既存のwordだった際に、既存のデータと入力したデータを両方表示し、それぞれに更新or編集ができるようにした

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -70,14 +70,15 @@ public class WordController {
 			// 入力されたcatgoryNameが登録済みではないか
 			Optional<Category> categoryOpt =  categoryService.searchByName(newCategoryName);
 			if (categoryOpt.isEmpty()) { // 登録済みではない -> categoryテーブルへ新規登録
-				int newCategoryId = categoryService.addCategory(newCategoryName);
-				wordForm.setCategoryId(newCategoryId);
+				Category newCategory = categoryService.addCategory(newCategoryName);
+				wordForm.setCategoryId(newCategory.getId());
 			} else { // 登録済み -> 登録済みのcategoryNameからcategoryIdを取得してフォームにセット
 				wordForm.setCategoryId(categoryOpt.get().getId());
 			}
 		}
-		// selectタグからcategoryIdの入力があった場合
+		// categoryIdからcategoryNameをセット
 		Optional<Category> categoryOpt = categoryService.findByCategoryId(wordForm.getCategoryId());
+		wordForm.setCategoryName(categoryOpt.get().getName());
 		if (categoryOpt.isEmpty()) {
 			return "regist_error";
 		}
@@ -89,7 +90,6 @@ public class WordController {
 			model.addAttribute("exists", wordOpt.isPresent());
 			return "regist_confirm";
 		}
-		wordForm.setCategoryName(categoryOpt.get().getName());
 		return "regist_confirm";
 	}
 
@@ -108,18 +108,9 @@ public class WordController {
 		if (categoryOpt.isEmpty()) {
 			return "regist_error";
 		}
-		//登録済みののwordでないかチェック
-		Optional<Word> wordOpt = wordService.findByWordName(wordForm.getWordName());
-		if (wordOpt.isPresent()) {
-			model.addAttribute("word", wordOpt.get());
-			model.addAttribute("categories", categoryService.findAll());
-			return "regist_confirm";
-		}
 		wordService.addWord(wordForm);
 		redirectAttribute.addFlashAttribute("regist_ok", "登録完了しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
 		return "redirect:/wordList";
 	}
-	
-
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
@@ -8,6 +8,6 @@ import com.example.demo.entity.Category;
 public interface CategoryService {
 	public List<Category> findAll();
 	public Optional<Category> findByCategoryId(Integer categoryId);
-	public Integer addCategory(String categoryName);
+	public Category addCategory(String categoryName);
 	public Optional<Category> searchByName(String categoryName);
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
@@ -29,11 +29,11 @@ public class CategoryServiceImpl implements CategoryService {
 	}
 	//nameで登録してそのidを返す
 	@Override
-	public Integer addCategory(String categoryName) {
+	public Category addCategory(String categoryName) {
 		Category category = new Category();
 		category.setName(categoryName);
 		categoryRepository.save(category);
-		return category.getId();
+		return category;
 	}
 
 }

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-
 <head>
 	<meta charset="UTF-8">
 	<title>登録確認</title>
 </head>
 <body>
 	<h1>登録確認</h1>
+	<!-- wordが既存だった場合 -->
 	<div th:if="${exists}">
-		<h2></h2><span th:text="${word.wordName}"></span>はすでに登録されています。</h2>
-		<table th:object="${word}">
+		<!-- 登録済みの内容 -->
+		<h2><span th:text="${word.wordName}"></span> はすでに登録されています。</h2>
+		<h3>【登録済みの内容】</h3>
+		<table th:object="${word}" border="1">
 			<tr>
 				<th>word</th>
 				<td th:text="*{wordName}"></td>
@@ -23,16 +25,67 @@
 				<td th:text="*{category.name}"></td>
 			</tr>
 		</table>
-		<a th:href="@{/registCancel}">新規登録をキャンセルする</a>
-		<form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}" method="post">
-			<button type="submit">登録内容を編集する</button>
-		</form>
-		<a th:href="@{/wordDetail/{id}(id=${word.id})}">wordDetailへ戻る</a>
+
+		<!-- 登録済み内容の選択肢 -->
+		<div>
+			<h4>この登録済みの内容に対して：</h4>
+			<ul>
+				<li>
+					<a th:href="@{/registCancel}">登録をキャンセルする</a>
+				</li>
+				<li>
+					<form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}" method="post" style="display:inline;">
+						<button type="submit">既存の登録内容を編集する</button>
+					</form>
+				</li>
+			</ul>
+		</div>
+		<!-- 入力された内容 -->
+		<h3>【あなたが入力した内容】</h3>
+		<table th:object="${wordForm}" border="1">
+			<tr>
+				<th>word</th>
+				<td th:text="*{wordName}"></td>
+			</tr>
+			<tr>
+				<th>content</th>
+				<td th:text="*{content}"></td>
+			</tr>
+			<tr>
+				<th>category</th>
+				<td th:text="*{categoryName}"></td>
+			</tr>
+		</table>
+
+		<!-- 入力内容の選択肢 -->
+		<div>
+			<h4>この入力内容に対して：</h4>
+			<ul>
+				<li>
+					<form th:action="@{/wordDetail/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
+						<input type="hidden" th:field="*{wordName}">
+						<input type="hidden" th:field="*{content}">
+						<input type="hidden" th:field="*{categoryId}">
+						<button type="submit">既存のwordをこの内容で上書きする</button>
+					</form>
+				</li>
+				<li>
+					<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}" style="display:inline;">
+						<input type="hidden" th:field="*{wordName}">
+						<input type="hidden" th:field="*{content}">
+						<input type="hidden" th:field="*{categoryId}">
+						<button type="submit">入力画面に戻って修正する</button>
+					</form>
+				</li>
+			</ul>
+		</div>
 	</div>
+
+	<!-- wordが未登録の場合 -->
 	<div th:unless="${exists}">
 		<h2>以下の内容で登録します</h2>
-		<form th:action="@{/regist}" method="post">
-			<table th:object="${wordForm}">
+		<form th:action="@{/regist}" method="post" th:object="${wordForm}">
+			<table>
 				<tr>
 					<th>word</th>
 					<td>
@@ -57,13 +110,12 @@
 			</table>
 			<button type="submit">登録する</button>
 		</form>
-		<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}">
+		<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}" style="display:inline;">
 			<input type="hidden" th:field="*{wordName}">
 			<input type="hidden" th:field="*{content}">
 			<input type="hidden" th:field="*{categoryId}">
-			<button type="submit">登録画面へ戻る</button>
+			<button type="submit">入力画面に戻って修正する</button>
 		</form>
 	</div>
 </body>
-
 </html>


### PR DESCRIPTION
![名称未設定ファイル drawio](https://github.com/user-attachments/assets/6a9c0bf2-ee18-4184-875c-4d728c2d2cf9)
