### PR TITLE
編集画面にて、遷移元によって戻るボタンの表示の切り替えを実装 close #27

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.demo.entity.Category;
@@ -60,8 +61,9 @@ public class WordDetailController {
 	
 	//word編集画面
 	@GetMapping("/{id}/editForm")
-	public String editWordForm(
+	public String showEditForm(
 			@PathVariable("id") Integer id,
+			@RequestParam(name = "fromRegistConfirm", required = false) String fromRegistConfirm,
 			Model model){
 		Optional<Word> wordOpt =  wordService.findById(id);
 		if(wordOpt.isEmpty()) {
@@ -73,11 +75,14 @@ public class WordDetailController {
 		wordForm.setWordName(word.getWordName());
 		wordForm.setContent(word.getContent());
 		wordForm.setCategoryId(word.getCategory().getId());
+		
 		model.addAttribute("wordForm", wordForm);
-		//category選択肢一覧をセット
 		model.addAttribute("categories", categoryService.findAll());
-		//編集用にwordもセット
-		model.addAttribute("word", word);	
+		model.addAttribute("word", word);
+		//regist_confirmから遷移した場合 戻るボタンを切り替えるためのフラグを用意
+		if(fromRegistConfirm != null) {
+			model.addAttribute("fromRegistConfirm", true);	
+		}
 		return "edit_word";	
 	}
 	//word編集

--- a/KnowledgeMap/src/main/resources/templates/edit_word.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_word.html
@@ -1,47 +1,57 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
 <head>
-<meta charset="UTF-8">
-<title>Insert title here</title>
+	<meta charset="UTF-8">
+	<title>Insert title here</title>
 </head>
+
 <body>
 	<h1>word編集</h1>
 	<p th:if="${word_duplicate} != null" th:text="${word_duplicate}"></p>
 	<form th:action="@{/wordDetail/{id}/edit(id=${word.id})}" method="post">
-	    <table th:object="${wordForm}">
-	        <tr>
-	            <th>word</th>
-	            <td>
-	                <input type="text" th:field="*{wordName}">
+		<table th:object="${wordForm}">
+			<tr>
+				<th>word</th>
+				<td>
+					<input type="text" th:field="*{wordName}">
 					<span th:errors="*{wordName}"></span>
-	            </td>
-	        </tr>
-	        <tr>              
-	            <th>content</th>
-	            <td>
-	                <textarea th:field="*{content}"></textarea>
+				</td>
+			</tr>
+			<tr>
+				<th>content</th>
+				<td>
+					<textarea th:field="*{content}"></textarea>
 					<span th:errors="*{content}"></span>
-	            </td>
-	        </tr>
-	        <tr>
-	            <th>category</th>
-	            <td>
-	                <select th:field="*{categoryId}" required>
-	                    <option value="">カテゴリを選択</option>
-	                    <option th:each="category : ${categories}" 
-								th:value="${category.id}"
-								th:text="${category.name}"
-								th:selected="${category.id} == ${word.id}">
+				</td>
+			</tr>
+			<tr>
+				<th>category</th>
+				<td>
+					<select th:field="*{categoryId}" required>
+						<option value="">カテゴリを選択</option>
+						<option th:each="category : ${categories}" th:value="${category.id}" th:text="${category.name}"
+							th:selected="${category.id} == ${word.id}">
 						</option>
-	                </select>
+					</select>
 					<span th:errors="*{categoryId}"></span>
-					<p>または新しいカテゴリーをつくる<input type="text" th:field="*{categoryName}" th:value="${#fields.hasErrors('*') or wordForm.categoryName != null ? wordForm.categoryName : ''}"></p>
+					<p>または新しいカテゴリーをつくる<input type="text" th:field="*{categoryName}"
+							th:value="${#fields.hasErrors('*') or wordForm.categoryName != null ? wordForm.categoryName : ''}">
+					</p>
 					<span th:errors="*{categoryNotNull}"></span>
-	            </td>
-	        </tr>               
-	    </table>
-	    <button type="submit">編集する</button>	
+				</td>
+			</tr>
+		</table>
+		<button type="submit">編集する</button>
 	</form>
-	<a th:href="@{/wordDetail/{id}(id=${word.id})}">wordDetailへ戻る</a>
+	<form th:if="${fromRegistConfirm}" th:action="@{/registConfirm}" method="post" th:object="${wordForm}">
+		<input type="hidden" th:field="*{wordName}">
+		<input type="hidden" th:field="*{content}">
+		<input type="hidden" th:field="*{categoryId}">
+		<button>登録確認に戻る</button>
+	</form>
+	<form th:unless="${fromRegistConfirm}" th:action="@{/wordDetail/{id}(id=${word.id})}">
+		<button>wordDetailへ戻る</button>		
+	</form>
 </body>
 </html>

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -34,7 +34,8 @@
 					<a th:href="@{/registCancel}">登録をキャンセルする</a>
 				</li>
 				<li>
-					<form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}" style="display:inline;">
+					<form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}">
+						<input type="hidden" th:name="fromRegistConfirm">
 						<button type="submit">既存の登録内容を編集する</button>
 					</form>
 				</li>
@@ -70,7 +71,7 @@
 					</form>
 				</li>
 				<li>
-					<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}" style="display:inline;">
+					<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}">
 						<input type="hidden" th:field="*{wordName}">
 						<input type="hidden" th:field="*{content}">
 						<input type="hidden" th:field="*{categoryId}">

--- a/KnowledgeMap/src/main/resources/templates/word_detail.html
+++ b/KnowledgeMap/src/main/resources/templates/word_detail.html
@@ -23,7 +23,7 @@
             <button type="submit">削除</button>
         </form>
         <form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}">
-            <button type="submit">変更</button>
+            <button type="submit">編集</button>
         </form>
 		<a th:href="@{/wordList}">一覧へ戻る</a>
 		


### PR DESCRIPTION
word編集画面には,
     word_Detailにて「編集」ボタンが押されたの場合
     regist_confirmにて「既存のwordを編集」ボタンが押された場合
の2パターンがあり。
それぞれの場合によって編集画面に表示する戻るボタンを切り替える実装及びテストを行なった。
遷移元がregist_confirmの場合は、fromRegistConfirmというフラグをたて、
フラグの有無でボタンの表示を切り替える。