### PR TITLE
関連語を自身のwordを選択できないようにした

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/entity/Word.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/entity/Word.java
@@ -13,6 +13,8 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.Data;
 
 /*
@@ -38,6 +40,7 @@ public class Word {
     private Category category;
 
     @ManyToMany
+    @JsonIgnore
     @JoinTable(
         name = "word_relation",
         joinColumns = @JoinColumn(name = "word_id"),

--- a/KnowledgeMap/src/main/resources/templates/edit_form.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_form.html
@@ -45,9 +45,10 @@
 						<li th:each="relatedWordName : ${relatedWordNames}" th:text="${relatedWordName}"></li>
 					</ul>
 					<select multiple th:field="*{relatedWordIds}">
-					    <option th:each="word : ${wordList}" 
-					            th:value="${word.id}" 
-					            th:text="${word.wordName}">
+					    <option th:each="relatedWord : ${wordList}" 
+								th:if="${relatedWord.id} != ${word.id}"
+					            th:value="${relatedWord.id}" 
+					            th:text="${relatedWord.wordName}">
 					    </option>
 					</select>
 				</td>


### PR DESCRIPTION
wordのrelatedWordsリストに@JsonIgnoreを付与して、循環参照を避けるようにしました。
編集時の関連語を選ぶ選択肢に、自身のwordは表示しないよう、edit_formのタイムリーフで制御。