### PR TITLE
関連語として登録のあるwordを削除するときのバグ修正

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/entity/WordRelation.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/entity/WordRelation.java
@@ -1,0 +1,29 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.Data;
+
+@Entity
+@Table(name = "word_relation")
+@Data
+public class WordRelation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "word_id")
+    private Word word;
+
+    @ManyToOne
+    @JoinColumn(name = "related_word_id")
+    private Word relatedWord;
+}
+

--- a/KnowledgeMap/src/main/java/com/example/demo/repository/WordRelationRepository.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/repository/WordRelationRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.entity.WordRelation;
+
+public interface WordRelationRepository extends JpaRepository<WordRelation,Integer>{
+	public void deleteByRelatedWordId(Integer id);
+	public void deleteByWordId(Integer id);
+}

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
@@ -6,11 +6,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.entity.Category;
 import com.example.demo.entity.Word;
 import com.example.demo.form.WordForm;
 import com.example.demo.repository.CategoryRepository;
+import com.example.demo.repository.WordRelationRepository;
 import com.example.demo.repository.WordRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class WordServiceImpl implements WordService {
 	private final WordRepository wordRepository;
 	private final CategoryRepository categoryRepository;
+	private final WordRelationRepository wordRelationRepository;
 	
 	//WordForm型からWord型への変換を行うユーティリティメソッド
 	public Word transferWordFormToWord(Word word,WordForm wordForm) {
@@ -70,10 +73,13 @@ public class WordServiceImpl implements WordService {
 	}
 
 	@Override
+	@Transactional
 	public boolean deleteById(Integer id) {
 		if(wordRepository.findById(id).isEmpty()) {
 			return false;
 		}
+		wordRelationRepository.deleteByWordId(id);
+		wordRelationRepository.deleteByRelatedWordId(id);
 		wordRepository.deleteById(id);
 		return true;
 	}


### PR DESCRIPTION
wordの削除を安全に行うため、
wordテーブルからwordを削除する前に
word_relationテーブルから削除したいwordのidを含むレコードを削除する。

これまではWordRelationクラスを用意しなくてもよかったが、
レコード削除するためにEntityクラスを作成した。

それに伴い、word_relationテーブルのキーを変更。
これまでは複合主キーだったが、これはJpaRepositoryで扱いづらいので
新たにidカラムを追加し主キーに設定した。