### PR TITLE
wordDetailが表示されると、word編集ボタンも表示され、編集ができる

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -108,6 +108,8 @@ public class WordController {
 	public String registCancel(Model model) {
 		model.addAttribute("regist_cancel", "登録がキャンセルされました");
 		model.addAttribute("wordList", wordService.findAll());
+		model.addAttribute("categories", categoryService.findAll());
+
 		return "word_list";
 	}
 

--- a/KnowledgeMap/src/main/resources/templates/edit_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_confirm.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>edit_confirm</h1>
 	<h2>以下の内容で編集します</h2>
-	<form th:action="@{/wordDetail/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
+	<form th:action="@{/words/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
 		<table>
 			<tr>
 				<th>word</th>
@@ -42,13 +42,14 @@
 		</table>
 		<button type="submit">登録する</button>
 	</form>
-	<form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}" th:object="${wordForm}"
+	<form th:action="@{/words/{id}/editForm(id=${word.id})}" th:object="${wordForm}"
 		style="display:inline;">
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">
 		<input type="hidden" th:field="*{relatedWordIds}">
 		<input type="hidden" th:field="*{categoryName}">
+		<input th:if="${fromRegist}" type="hidden" name="fromRegist" value="${fromRegist}">
 		<button type="submit">編集画面に戻って修正する</button>
 	</form>
 	</div>

--- a/KnowledgeMap/src/main/resources/templates/edit_form.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_form.html
@@ -9,7 +9,7 @@
 <body>
 	<h1>word編集</h1>
 	<p th:if="${word_duplicate} != null" th:text="${word_duplicate}"></p>
-	<form th:action="@{/wordDetail/{id}/editConfirm(id=${word.id})}" method="post">
+	<form th:action="@{/words/{id}/editConfirm(id=${word.id})}" method="post">
 		<table th:object="${wordForm}">
 			<tr>
 				<th>word</th>
@@ -54,17 +54,22 @@
 				</td>
 			</tr>
 		</table>
+		<input th:if="${fromRegist}" type="hidden" name="fromRegist" value="${fromRegist}">
 		<button type="submit">編集内容確認</button>
 	</form>
-	<form th:if="${fromRegistConfirm}" th:action="@{/registConfirm}" method="post" th:object="${wordForm}">
+	<!-- 新規登録からの遷移の場合、戻るボタンは 登録画面へ -->
+	<form th:if="${fromRegist}" th:action="@{/registConfirm}" method="post" th:object="${wordForm}">
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">
 		<input type="hidden" th:field="*{relatedWordIds}">
 		<button>登録確認に戻る</button>
 	</form>
-	<form th:unless="${fromRegistConfirm}" th:action="@{/wordDetail/{id}(id=${word.id})}">
-		<button>wordDetailへ戻る</button>		
+	<!-- 編集からの遷移の場合、戻るボタンはword一覧へ-->
+	<form th:unless="${fromRegist}" th:action="@{/wordList}">
+		<input type="hidden" th:field="${wordForm.categoryId}">
+		<input type="hidden" th:field="${word.id}">
+		<button>word一覧へ</button>		
 	</form>
 </body>
 </html>

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -42,8 +42,8 @@
 					<a th:href="@{/registCancel}">登録をキャンセルする</a>
 				</li>
 				<li>
-					<form th:action="@{/wordDetail/{id}/editForm(id=${word.id})}">
-						<input type="hidden" th:name="fromRegistConfirm">
+					<form th:action="@{/words/{id}/editForm(id=${word.id})}">
+						<input type="hidden" name="fromRegist" value="fromRegist">
 						<button type="submit">既存の登録内容を編集する</button>
 					</form>
 				</li>
@@ -80,7 +80,7 @@
 			<h4>この入力内容に対して：</h4>
 			<ul>
 				<li>
-					<form th:action="@{/wordDetail/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
+					<form th:action="@{words/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
 						<input type="hidden" th:field="*{wordName}">
 						<input type="hidden" th:field="*{content}">
 						<input type="hidden" th:field="*{categoryId}">

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -35,6 +35,7 @@
 				<ul id="relatedWordList"></ul>
 			</span>
 		</p>
+		<div id="editBtnContainer"></div>
 	</div>
 </body>
 

--- a/KnowledgeMap/src/test/java/com/example/demo/controller/WordDetailControllerTest.java
+++ b/KnowledgeMap/src/test/java/com/example/demo/controller/WordDetailControllerTest.java
@@ -94,8 +94,8 @@ public class WordDetailControllerTest {
 
 	@Test
 	void testShowDetail() throws Exception {
-		doNothing().when(wordService).deleteById(1);
-		mockMvc.perform(get("/wordDetail/{id}", 1))
+		doReturn(true).when(wordService).deleteById(1);
+		mockMvc.perform(get("/words/{id}", 1))
 				.andExpect(status().isOk())
 				.andExpect(view().name("word_detail"))
 				.andExpect(model().attributeExists("word"))
@@ -105,7 +105,7 @@ public class WordDetailControllerTest {
 	@Test
 	//削除成功
 	void testDeleteWord_ExistingWord() throws Exception {
-		mockMvc.perform(post("/wordDetail/{id}/delete", 1))
+		mockMvc.perform(post("/words/{id}/delete", 1))
 				.andExpect(status().is3xxRedirection())
 				.andExpect(redirectedUrl("/wordList"))
 				.andExpect(flash().attribute("delete_ok", "wordを削除しました"));
@@ -114,7 +114,7 @@ public class WordDetailControllerTest {
 	@Test
 	//削除失敗(存在しないidを指定)
 	void testDeleteWord_NotExistWord() throws Exception {
-		mockMvc.perform(post("/wordDetail/{id}/delete", 999))
+		mockMvc.perform(post("/words/{id}/delete", 999))
 				.andExpect(status().is3xxRedirection())
 				.andExpect(redirectedUrl("/wordList"))
 				.andExpect(flash().attribute("delete_error", "指定されたwordは存在しません"));
@@ -124,7 +124,7 @@ public class WordDetailControllerTest {
 	@Test
 	//編集画面表示 成功
 	void testShowEditForm() throws Exception {
-		mockMvc.perform(get("/wordDetail/{id}/editForm", 1))
+		mockMvc.perform(get("/words/{id}/editForm", 1))
 				.andExpect(status().isOk())
 				.andExpect(view().name("edit_form"))
 				.andExpect(model().attributeExists("word"));
@@ -134,14 +134,14 @@ public class WordDetailControllerTest {
 	//編集画面表示 失敗
 	void testShowEditForm_NotExistsWord() throws Exception {
 		doReturn(Optional.empty()).when(wordService).findById(999);
-		mockMvc.perform(get("/wordDetail/{id}/editForm", 999))
+		mockMvc.perform(get("/words/{id}/editForm", 999))
 				.andExpect(status().isOk())
 				.andExpect(view().name("edit_error"));
 	}
 	@Test
 	//編集画面表示 ( 遷移元がword_detail )
 	void testShowEditForm_FromWordDetail() throws Exception {
-		mockMvc.perform(get("/wordDetail/{id}/editForm", 1))
+		mockMvc.perform(get("/words/{id}/editForm", 1))
 				.andExpect(status().isOk())
 				.andExpect(view().name("edit_form"))
 				.andExpect(model().attributeDoesNotExist("fromRegistConfirm"))
@@ -149,7 +149,7 @@ public class WordDetailControllerTest {
 	}
 	//編集画面表示 ( 遷移元がregist_confirm )
 	void testShowEditForm_FromRegistConfirm() throws Exception {
-		mockMvc.perform(get("/wordDetail/{id}/editForm", 1)
+		mockMvc.perform(get("/words/{id}/editForm", 1)
 				.param("fromRegistConfirm", "true"))
 				.andExpect(status().isOk())
 				.andExpect(view().name("edit_word"))
@@ -159,7 +159,7 @@ public class WordDetailControllerTest {
 	@Test
 	//編集確認 バリデーションエラー発生
 	void testEditConfirm() throws Exception {
-		mockMvc.perform(post("/wordDetail/{id}/editConfirm", 2)
+		mockMvc.perform(post("/words/{id}/editConfirm", 2)
 				.param("id", "2")
 				.param("wordName", "")
 				.param("content", "")
@@ -174,7 +174,7 @@ public class WordDetailControllerTest {
 		form.setWordName("newWordName");
 		form.setContent("newContent");
 		form.setCategoryId(2);
-		mockMvc.perform(post("/wordDetail/{id}/editConfirm", 1)
+		mockMvc.perform(post("/words/{id}/editConfirm", 1)
 				.param("wordName", "notExistingWordName")
 				.param("content", "newContent")
 				.param("categoryId", "2")
@@ -194,7 +194,7 @@ public class WordDetailControllerTest {
 		WordForm form = new WordForm();
 		form.setWordName("newWordName");
 		form.setContent("newContent");
-		mockMvc.perform(post("/wordDetail/{id}/editConfirm", 1)
+		mockMvc.perform(post("/words/{id}/editConfirm", 1)
 				.param("wordName", "notExistingWordName")
 				.param("content", "newContent")
 				.param("categoryId", "")
@@ -203,10 +203,7 @@ public class WordDetailControllerTest {
 				.andExpect(view().name("edit_confirm"))
 				.andExpect(model().attribute("wordForm",hasProperty("categoryName",is("newCategoryName"))));
 		verify(categoryService, atLeastOnce()).addCategory("newCategoryName");
-//		ArgumentCaptor<WordForm> captor = ArgumentCaptor.forClass(WordForm.class);
-//		verify(wordService, atLeastOnce()).updateWord(eq(1), captor.capture());
-//		WordForm argForm = captor.getValue();
-//		assertThat(argForm.getCategoryId()).isEqualTo(2);
+
 	}
 	@Test
 	//編集実行 ( wordカブリなし,categoryName入力あり,categoryNameは既存 -> 既存のcategoryIdで更新 )
@@ -214,7 +211,7 @@ public class WordDetailControllerTest {
 		WordForm form = new WordForm();
 		form.setWordName("newWordName");
 		form.setContent("newContent");
-		mockMvc.perform(post("/wordDetail/{id}/editConfirm", 1)
+		mockMvc.perform(post("/words/{id}/editConfirm", 1)
 				.param("wordName", "notExistingWordName")
 				.param("content", "newContent")
 				.param("categoryId", "")
@@ -231,7 +228,7 @@ public class WordDetailControllerTest {
 	@Test
 	//編集確認 ( wordカブリあり -> 　入力フォームのビューを返し、かぶってるメッセージを表示 )
 	void testEditConfirm_ExistingWord() throws Exception {
-		mockMvc.perform(post("/wordDetail/{id}/editConfirm", 1)
+		mockMvc.perform(post("/words/{id}/editConfirm", 1)
 				.param("wordName", "ExistingWordName")
 				.param("content", "newContent")
 				.param("categoryId", "")
@@ -243,7 +240,7 @@ public class WordDetailControllerTest {
 	@Test
 	//編集実行
 	void testEdit() throws Exception{
-		mockMvc.perform(post("/wordDetail/{id}/edit",1)
+		mockMvc.perform(post("/words/{id}/edit",1)
 		.param("wordName", "NotExistingWordName")
 		.param("content", "newContent")
 		.param("categoryId", "2")


### PR DESCRIPTION
word_list.htmlにて、wordのクリックイベントで編集ボタンを表示
編集ボタンは、wordDetailControllerへリクエストを送り、edit_form.htmlを返す
wordDetailControllerへの編集リクエストを /wordDetail/{id}/editForm  から  /words/{id}/editForm へ。
(編集を実行する前に、fetchで/words/{id}へリクエストしてwordDetailを表示してるから、一応揃えてみた)


 word_list.jsにて、edit_formから戻るときに、それまで表示していたwordDetailやwordListを再表示させるため、
戻るボタンクリック時にリクエストパラメータでword.idやcategoryIdを取得できるように変更


edit_form.htmlにて、表示させる戻るボタンは、遷移元がどこかによって種類が変わる
以前にfromRegistConfirmというフラグで表示切り替えをしていたが、
画面をさらに進めてedit_confirmまで行ってから戻るとフラグが消えてしまって切り替えが失敗していたので
フラグを立ててモデルに追加する処理を editConfirmメソッドにも追加
