### PR TITLE
word新規登録時、関連語に自身のwordNameを登録しようとするとバリデーションエラーを発生させる

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordApiController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordApiController.java
@@ -24,8 +24,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 
 public class WordApiController {
+	
 	private final WordService wordService;
 	private final CategoryService categoryService;
+	
 	@GetMapping("/words")
 	public List<Word> getWordsByCategoryId(@RequestParam("categoryId") Integer categoryId){
 		return wordService.findByCategoryId(categoryId);

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -17,6 +19,7 @@ import com.example.demo.entity.Word;
 import com.example.demo.form.WordForm;
 import com.example.demo.service.CategoryService;
 import com.example.demo.service.WordService;
+import com.example.demo.validator.WordFormValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +28,12 @@ import lombok.RequiredArgsConstructor;
 public class WordController {
 	private final WordService wordService;
 	private final CategoryService categoryService;
-
+	private final WordFormValidator wordFormValidator;
+	
+	@InitBinder("wordForm")
+	public void initBinder(WebDataBinder webDataBinder) {
+		webDataBinder.addValidators(wordFormValidator);
+	}
 	// word一覧表示
 	@GetMapping("/wordList")
 	public String showWordList(Model model) {
@@ -63,8 +71,11 @@ public class WordController {
 			@Validated WordForm wordForm,
 			BindingResult result,
 			Model model) {
+		String inputWordName = wordForm.getWordName();
 		if (result.hasErrors()) {
 			model.addAttribute("categories", categoryService.findAll());
+			model.addAttribute("wordList", wordService.findAll());
+
 			return "regist_form";
 		}
 		// categoryNameに入力があった場合
@@ -85,7 +96,6 @@ public class WordController {
 			return "regist_error";
 		}
 		wordForm.setCategoryName(categoryOpt.get().getName());
-		
 		List<Integer> relatedWordIds = wordForm.getRelatedWordIds();
 		List<String> relatedWordNames = relatedWordIds.stream()
 				.map(id -> wordService.findById(id))

--- a/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
@@ -1,0 +1,35 @@
+package com.example.demo.validator;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import com.example.demo.form.WordForm;
+import com.example.demo.service.WordService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WordFormValidator implements Validator {
+	private final WordService wordService;
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return WordForm.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	public void validate(Object target, Errors errors) {
+		WordForm wordForm = (WordForm) target;
+		List<String> relatedWordNames = wordForm.getRelatedWordIds().stream()
+				.map(relatedWordId -> wordService.findById(relatedWordId))
+				.filter(opt -> opt.isPresent())
+				.map(opt -> opt.get().getWordName())
+				.toList();
+		if(relatedWordNames.contains(wordForm.getWordName())) {
+			errors.rejectValue("relatedWordIds",null,"自身のwordは関連語として登録できません");
+		}
+	}
+}

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -44,7 +44,8 @@
 					            th:value="${word.id}" 
 					            th:text="${word.wordName}">
 					    </option>
-					</select>			
+					</select>	
+					<span th:errors="*{relatedWordIds}"></span>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
Validator インタフェースを継承した wordFormValidator クラスを作成し、
relatedWordIdsフィールドに関するバリデーションを行うメソッドを追加。
(relatedWordIds から取得した  relatedWordNames リストに、ユーザが入力したwordNameが含まれていたらエラー発生)

ユーザが既存の wordName を入力した時に
同じ wordName の関連語を登録できないようになった。