### PR TITLE
word新規登録 既存のwordを登録しようとするとバリデーションエラー発生　close #45

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -71,22 +71,24 @@ public class WordController {
 			@Validated WordForm wordForm,
 			BindingResult result,
 			Model model) {
-		String inputWordName = wordForm.getWordName();
 		if (result.hasErrors()) {
 			model.addAttribute("categories", categoryService.findAll());
 			model.addAttribute("wordList", wordService.findAll());
-
+			// 既存word情報をmodelに格納
+			Optional<Word> wordOpt = wordService.findByWordName(wordForm.getWordName());
+			if (wordOpt.isPresent()) {
+				model.addAttribute("existingWord", wordOpt.get());
+			}
 			return "regist_form";
 		}
 		// categoryNameに入力があった場合
 		String newCategoryName = wordForm.getCategoryName();
 		if (newCategoryName != null && !newCategoryName.isBlank()) {
-			// 入力されたcatgoryNameが登録済みではないか
 			Optional<Category> categoryOpt =  categoryService.searchByName(newCategoryName);
-			if (categoryOpt.isEmpty()) { // 登録済みではない -> categoryテーブルへ新規登録
+			if (categoryOpt.isEmpty()) { // 入力されたcategoryNameが未登録 -> categoryテーブルへ新規登録
 				Category newCategory = categoryService.addCategory(newCategoryName);
 				wordForm.setCategoryId(newCategory.getId());
-			} else { // 登録済み -> 登録済みのcategoryNameからcategoryIdを取得してフォームにセット
+			} else { // 登録済 -> 登録済のcategoryNameからcategoryIdを取得してフォームにセット
 				wordForm.setCategoryId(categoryOpt.get().getId());
 			}
 		}
@@ -103,26 +105,17 @@ public class WordController {
 				.map(wordOpt -> wordOpt.get().getWordName())
 				.toList();
 		model.addAttribute("relatedWordNames",relatedWordNames);
-		//登録しようとしてるwordがすでに存在しているか確認
-		Optional<Word> wordOpt = wordService.findByWordName(wordForm.getWordName());
-		if (wordOpt.isPresent()) {
-			model.addAttribute("word", wordOpt.get());
-			model.addAttribute("categories", categoryService.findAll());
-			model.addAttribute("exists", true);
-			return "regist_confirm";
-		}
+
 		return "regist_confirm";
 	}
-
-	@GetMapping("/registCancel")
-	public String registCancel(Model model) {
-		model.addAttribute("regist_cancel", "登録がキャンセルされました");
-		model.addAttribute("wordList", wordService.findAll());
-		model.addAttribute("categories", categoryService.findAll());
-
-		return "word_list";
-	}
-
+//	@GetMapping("/registCancel")
+//	public String registCancel(Model model) {
+//		model.addAttribute("regist_cancel", "登録がキャンセルされました");
+//		model.addAttribute("wordList", wordService.findAll());
+//		model.addAttribute("categories", categoryService.findAll());
+//
+//		return "word_list";
+//	}
 	//DB新規登録
 	@PostMapping("/regist")
 	public String regist(WordForm wordForm,RedirectAttributes redirectAttribute) {

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +22,7 @@ import com.example.demo.entity.Word;
 import com.example.demo.form.WordForm;
 import com.example.demo.service.CategoryService;
 import com.example.demo.service.WordService;
+import com.example.demo.validator.WordFormValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +32,12 @@ import lombok.RequiredArgsConstructor;
 public class WordDetailController {
 	private final WordService wordService;
 	private final CategoryService categoryService;
+	private final WordFormValidator wordFormValidator;
+	
+	@InitBinder("wordForm")
+	public void initBinder(WebDataBinder webDataBinder) {
+		webDataBinder.addValidators(wordFormValidator);
+	}
 	
 	//wordFormのrelatedWordIds(List<Integer>)からrelatedWordNames(List<String>)へ変換するメソッド
 	public List<String> getRelatedWordNames(WordForm wordForm){
@@ -90,6 +99,7 @@ public class WordDetailController {
 		}
 		Word word = wordOpt.get();
 		// 編集用wordFormに、DBから検索したwordの値をセット
+		wordForm.setId(word.getId()); 
 		wordForm.setWordName(word.getWordName());
 		wordForm.setContent(word.getContent());
 		wordForm.setCategoryId(word.getCategory().getId());
@@ -133,17 +143,6 @@ public class WordDetailController {
 			model.addAttribute("wordList",wordService.findAll());
 			model.addAttribute("word", word);
 			model.addAttribute("categories", categoryService.findAll());
-			return "edit_form";
-		}
-		//wordNameがカブっていたら 入力情報をモデルに格納して 入力フォーム画面へ返す
-		Optional<Word> existingWordOpt = wordService.findByWordName(wordForm.getWordName());
-		if (existingWordOpt.isPresent() && !existingWordOpt.get().getId().equals(id)) {
-			model.addAttribute("relatedWordNames",getRelatedWordNames(wordForm));
-			model.addAttribute("wordList",wordService.findAll());
-			model.addAttribute("word", word);
-			model.addAttribute("categories", categoryService.findAll());
-			
-			model.addAttribute("word_duplicate", existingWordOpt.get().getWordName() + "は既に登録済です");
 			return "edit_form";
 		}
 		String newCategoryName = wordForm.getCategoryName();

--- a/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
@@ -9,6 +9,7 @@ import lombok.Data;
 
 @Data
 public class WordForm {
+	private Integer id;
 	@NotBlank(message="wordが空です")
     private String wordName;
 	@NotBlank(message="contentが空です")

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
@@ -26,6 +26,7 @@ public class WordServiceImpl implements WordService {
 	
 	//WordForm型からWord型への変換を行うユーティリティメソッド
 	public Word transferWordFormToWord(Word word,WordForm wordForm) {
+		word.setId(wordForm.getId());
 		word.setWordName(wordForm.getWordName());
 		word.setContent(wordForm.getContent());
 		// wordForm型の categoryId から Category型に変換して Word型にセット

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -6,63 +6,29 @@
 </head>
 <body>
 	<h1>登録確認</h1>
-	<!-- wordが既存だった場合 -->
-	<div th:if="${exists}">
-		<!-- 登録済みの内容 -->
-		<h2><span th:text="${word.wordName}"></span> はすでに登録されています。</h2>
-		<h3>【登録済みの内容】</h3>
-		<table th:object="${word}" border="1">
+	<h2>以下の内容で登録します</h2>
+	<form th:action="@{/regist}" method="post" th:object="${wordForm}">
+		<table>
 			<tr>
 				<th>word</th>
-				<td th:text="*{wordName}"></td>
-			</tr>
-			<tr>
-				<th>content</th>
-				<td th:text="*{content}"></td>
-			</tr>
-			<tr>
-				<th>category</th>
-				<td th:text="*{category.name}"></td>
-			</tr>
-			<tr>
-				<th>related_words</th>
 				<td>
-					<ul>
-						<li th:each="relatedWord : *{relatedWords}" th:text="${relatedWord.wordName}"></li>
-					</ul>
+					<span th:text="*{wordName}"></span>
+					<input type="hidden" th:field="*{wordName}">
 				</td>
 			</tr>
-		</table>
-
-		<!-- 登録済み内容の選択肢 -->
-		<div>
-			<h4>この登録済みの内容に対して：</h4>
-			<ul>
-				<li>
-					<a th:href="@{/registCancel}">登録をキャンセルする</a>
-				</li>
-				<li>
-					<form th:action="@{/words/{id}/editForm(id=${word.id})}">
-						<input type="hidden" name="fromRegist" value="fromRegist">
-						<button type="submit">既存の登録内容を編集する</button>
-					</form>
-				</li>
-			</ul>
-		</div>
-		<!-- 入力された内容 -->
-		<h3>【あなたが入力した内容】</h3>
-		<table th:object="${wordForm}" border="1">
-			<tr>
-				<th>word</th>
-				<td th:text="*{wordName}"></td>
-			</tr>
 			<tr>
 				<th>content</th>
-				<td th:text="*{content}"></td>
+				<td>
+					<span th:text="*{content}"></span>
+					<input type="hidden" th:field="*{content}">
+				</td>
 			</tr>
 			<tr>
 				<th>category</th>
-				<td th:text="*{categoryName}"></td>
+				<td>
+					<span th:text="*{categoryName}"></span>
+					<input type="hidden" th:field="*{categoryId}">
+				</td>
 			</tr>
 			<tr>
 				<th>related_words</th>
@@ -70,82 +36,20 @@
 					<ul>
 						<li th:each="relatedWordName : ${relatedWordNames}" th:text="${relatedWordName}"></li>
 					</ul>
+					<input type="hidden" th:field="*{relatedWordIds}">
 				</td>
 			</tr>
-
 		</table>
-
-		<!-- 入力内容の選択肢 -->
-		<div>
-			<h4>この入力内容に対して：</h4>
-			<ul>
-				<li>
-					<form th:action="@{words/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
-						<input type="hidden" th:field="*{wordName}">
-						<input type="hidden" th:field="*{content}">
-						<input type="hidden" th:field="*{categoryId}">
-						<input type="hidden" th:field="*{relatedWordIds}">
-						<button type="submit">既存のwordをこの内容で上書きする</button>
-					</form>
-				</li>
-				<li>
-					<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}">
-						<input type="hidden" th:field="*{wordName}">
-						<input type="hidden" th:field="*{content}">
-						<input type="hidden" th:field="*{categoryId}">
-						<input type="hidden" th:field="*{relatedWordIds}">
-						<button type="submit">入力画面に戻って修正する</button>
-					</form>
-				</li>
-			</ul>
-		</div>
-	</div>
-
-	<!-- wordが未登録の場合 -->
-	<div th:unless="${exists}">
-		<h2>以下の内容で登録します</h2>
-		<form th:action="@{/regist}" method="post" th:object="${wordForm}">
-			<table>
-				<tr>
-					<th>word</th>
-					<td>
-						<span th:text="*{wordName}"></span>
-						<input type="hidden" th:field="*{wordName}">
-					</td>
-				</tr>
-				<tr>
-					<th>content</th>
-					<td>
-						<span th:text="*{content}"></span>
-						<input type="hidden" th:field="*{content}">
-					</td>
-				</tr>
-				<tr>
-					<th>category</th>
-					<td>
-						<span th:text="*{categoryName}"></span>
-						<input type="hidden" th:field="*{categoryId}">
-					</td>
-				</tr>
-				<tr>
-					<th>related_words</th>
-					<td>
-						<ul>
-							<li th:each="relatedWordName : ${relatedWordNames}" th:text="${relatedWordName}"></li>
-						</ul>
-						<input type="hidden" th:field="*{relatedWordIds}">
-					</td>
-				</tr>
-			</table>
-			<button type="submit">登録する</button>
-		</form>
-		<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}" style="display:inline;">
-			<input type="hidden" th:field="*{wordName}">
-			<input type="hidden" th:field="*{content}">
-			<input type="hidden" th:field="*{categoryId}">
-			<input type="hidden" th:field="*{relatedWordIds}">
-			<button type="submit">入力画面に戻って修正する</button>
-		</form>
+		<button type="submit">登録する</button>
+	</form>
+	<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}" style="display:inline;">
+		<input type="hidden" th:field="*{wordName}">
+		<input type="hidden" th:field="*{content}">
+		<input type="hidden" th:field="*{categoryId}">
+		<input type="hidden" th:field="*{relatedWordIds}">
+		<button type="submit">入力画面に戻って修正する</button>
+	</form>
 	</div>
 </body>
+
 </html>

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -10,6 +10,7 @@
 	<h1>新規登録</h1>
 	<form th:action="@{/registConfirm}" method="post">
 		<table th:object="${wordForm}" border="1">
+		<input type="hidden" th:field="*{id}">
 			<tr>
 				<th>word</th>
 				<td>
@@ -32,7 +33,7 @@
 						<option th:each="category : ${categories}" th:value="${category.id}" th:text="${category.name}">
 						</option>
 					</select>
-					<p>または新しいカテゴリーをつくる<input type="text" th:field="*{categoryName}"></p>
+					<span>または新しいカテゴリーをつくる<input type="text" th:field="*{categoryName}"></span>
 					<span th:errors="*{categoryNotNull}"></span>
 				</td>
 			</tr>
@@ -40,11 +41,9 @@
 				<th>relatedWords</th>
 				<td>
 					<select multiple th:field="*{relatedWordIds}">
-					    <option th:each="word : ${wordList}" 
-					            th:value="${word.id}" 
-					            th:text="${word.wordName}">
-					    </option>
-					</select>	
+						<option th:each="word : ${wordList}" th:value="${word.id}" th:text="${word.wordName}">
+						</option>
+					</select>
 					<span th:errors="*{relatedWordIds}"></span>
 				</td>
 			</tr>
@@ -52,6 +51,36 @@
 		<button>登録内容の確認</button>
 	</form>
 	<a th:href="@{/wordList}">一覧へ戻る</a>
+
+	<div th:if="${existingWord} != null">
+		<h3>【登録済みの内容】</h3>
+		<table th:object="${existingWord}" border="1">
+			<tr>
+				<th>word</th>
+				<td th:text="*{wordName}"></td>
+			</tr>
+			<tr>
+				<th>content</th>
+				<td th:text="*{content}"></td>
+			</tr>
+			<tr>
+				<th>category</th>
+				<td th:text="*{category.name}"></td>
+			</tr>
+			<tr>
+				<th>related_words</th>
+				<td>
+					<ul>
+						<li th:each="relatedWord : *{relatedWords}" th:text="${relatedWord.wordName}"></li>
+					</ul>
+				</td>
+			</tr>
+		</table>
+		<form th:action="@{/words/{id}/editForm(id=${existingWord.id})}">
+			<input type="hidden" name="fromRegist" value="fromRegist">
+			<button type="submit">既存の登録内容を編集する</button>
+		</form>
+	</div>
 </body>
 
 </html>


### PR DESCRIPTION
### WordFormValidatorクラス
新規登録と編集の際に既存のwordNameで更新しようとすると
バリデーションエラーが発生するように変更。

### regist_form.html(入力フォーム)
wordNameフィールドに上記のバリデーションエラーが発生すると、
既存のwordの情報が表示され、さらにそのwordを編集できるように
編集ボタンを追加した。

### regist_confirm.html(登録確認)
regist_form.htmlで既存wordだった時の確認を済ませているので、
ここではシンプルに登録内容の確認を行い、
登録 or 再入力 の選択肢のみとする。

