### PR TITLE
既存カテゴリを選択 or 新規カテゴリを入力 のどちらかしか選択できないように変更した

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
@@ -26,18 +26,18 @@ public class WordFormValidator implements Validator {
 	@Override
 	public void validate(Object target, Errors errors) {
 		WordForm wordForm = (WordForm) target;
+		// 関連語に自身のwordを選択するとエラー
 		if (wordForm.getRelatedWordIds() != null) {
 			List<String> relatedWordNames = wordForm.getRelatedWordIds().stream()
 					.map(relatedWordId -> wordService.findById(relatedWordId))
 					.filter(opt -> opt.isPresent())
 					.map(opt -> opt.get().getWordName())
 					.toList();
-			// 関連語に自身のwordを選択していないか
 			if (relatedWordNames.contains(wordForm.getWordName())) {
 				errors.rejectValue("relatedWordIds", null, "自身のwordは関連語として登録できません");
 			}
 		}
-		// 既存wordNameかどうか
+		// 既存wordNameならエラー
 		Optional<Word> existingWordOpt = wordService.findByWordName(wordForm.getWordName());
 		if (existingWordOpt.isPresent()) {
 			Word existingWord = existingWordOpt.get();
@@ -48,6 +48,10 @@ public class WordFormValidator implements Validator {
 			if (wordForm.getId() == null || !wordForm.getId().equals(existingWord.getId())) {
 				errors.rejectValue("wordName", null, wordForm.getWordName() + "はすでに登録されています");
 			}
+		}
+		//categoryIdとcategoryNameの両方に入力があればエラー
+		if(wordForm.getCategoryId() != null && wordForm.getCategoryName() != null && !wordForm.getCategoryName().isBlank()) {
+			errors.rejectValue("categoryId", null,"新規カテゴリを入力した場合は、カテゴリを選択できません");
 		}
 	}
 }

--- a/KnowledgeMap/src/main/resources/static/js/form.js
+++ b/KnowledgeMap/src/main/resources/static/js/form.js
@@ -1,0 +1,10 @@
+const categorySelect = document.getElementById("categoryId");//既存カテゴリの選択
+const categoryInput = document.getElementById("categoryName");//新規カテゴリの入力
+//新規カテゴリの入力があれば、既存カテゴリの選択はできない状態にする
+categoryInput.addEventListener("input", () => {
+	if (categoryInput.value !== "") {
+		categorySelect.disabled = true;
+	} else {
+		categorySelect.disabled = false;
+	}
+});

--- a/KnowledgeMap/src/main/resources/templates/edit_form.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_form.html
@@ -4,6 +4,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>word編集</title>
+	<script th:src="@{/js/form.js}" defer></script>
+
 </head>
 
 <body>

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -4,6 +4,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>単語の登録</title>
+	<script th:src="@{/js/form.js}" defer></script>
 </head>
 
 <body>


### PR DESCRIPTION
### カテゴリ選択の挙動を変更

これまで「新規カテゴリ入力 ＋ 既存カテゴリ選択」の両方があった場合、
新規カテゴリが優先されて登録されていた
　　　↓
「どちらか一方のみ選択可」となるようにブラウザ側とサーバ側で制御を追加
#### 変更点
<フロント側>
新規カテゴリに入力の値がある間は 既存カテゴリのselectタグは無効化し、
入力値が ""(空文字)となれば selectタグを復活させるjsファイルを作成

<サーバ側>
WordFormValidatorクラスにバリデーション追加
categoryIdとcategoryNameの両方の入力がある場合はエラーを発生させる。