### PR TITLE
Feature/#55 word detail container show

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -101,9 +101,9 @@ public class WordController {
 		if (categoryOpt.isEmpty()) {
 			return "regist_error";
 		}
-		wordService.addWord(wordForm);
+		Word registedWord = wordService.addWord(wordForm);
 		redirectAttribute.addFlashAttribute("regist_ok", "登録完了しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
-		return "redirect:/wordList";
+		return String.format("redirect:/wordList?categoryId=%d&id=%d", registedWord.getCategory().getId(),registedWord.getId());
 	}
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -124,9 +124,9 @@ public class WordDetailController {
 	public String edit(WordForm wordForm,
 			@PathVariable("id") Integer id,
 			RedirectAttributes redirectAttribute) {
-		wordService.updateWord(id, wordForm);
+		Word updatedWord = wordService.updateWord(id, wordForm);
 		redirectAttribute.addFlashAttribute("edit_ok", "編集が完了しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
-		return "redirect:/wordList";
+		return String.format("redirect:/wordList?categoryId=%d&id=%d", updatedWord.getCategory().getId(),updatedWord.getId());
 	}
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
@@ -9,11 +9,11 @@ import com.example.demo.form.WordForm;
 public interface WordService {
 
 	public Optional<Word> findByWordName(String name);
-	public void addWord(WordForm wordForm);
+	public Word addWord(WordForm wordForm);
     public List<Word> findAll();
     public Optional<Word> findById(Integer id);
     public boolean deleteById(Integer id);
-    public void updateWord(Integer id, WordForm wordForm);
+    public Word updateWord(Integer id, WordForm wordForm);
     public List<Word> findByCategoryId(Integer id);
     public List<String> getRelatedWordNames(WordForm wordForm);
     

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
@@ -84,17 +84,17 @@ public class WordServiceImpl implements WordService {
 	}
 
 	@Override
-	public void addWord(WordForm wordForm) {
+	public Word addWord(WordForm wordForm) {
 		Word word = new Word();
 		transferWordFormToWord(word, wordForm);//WordForm型 -> Word型　の変換
-		wordRepository.save(word);
+		return wordRepository.save(word);
 	}
 
 	@Override
-	public void updateWord(Integer id, WordForm wordForm) {
+	public Word updateWord(Integer id, WordForm wordForm) {
 		Optional<Word> wordOpt = wordRepository.findById(id);
 		Word word = wordOpt.get();
 		transferWordFormToWord(word, wordForm);//WordForm型 -> Word型　の変換
-		wordRepository.save(word);
+		return  wordRepository.save(word);
 	}
 }

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -5,3 +5,9 @@
 .deleteBtnVisible{
     display: inline;
 }
+.wordDetailHidden{
+	display: none;
+}
+.wordDetailVisible{
+	display: inline;
+}

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -1,17 +1,18 @@
 
 let selectedCategoryId = null;//現在表示されているカテゴリのidを保持する用
-const wordContainer = document.getElementById("wordContainer");
+const wordList = document.getElementById("wordList");
 const categoryBtns = document.querySelectorAll(".categoryBtn");
 const wordName = document.getElementById("detail-wordName");
 const content = document.getElementById("detail-content");
 const category = document.getElementById("detail-category");
-const relatedWordList = document.getElementById("relatedWordList");
+const relatedWords = document.getElementById("relatedWords");
 const editBtnContainer = document.getElementById("editBtnContainer");
+const wordDetailContainer = document.querySelector(".wordDetailHidden");
 
 //カテゴリ名をクリック -> そのカテゴリに属するword一覧を表示
 categoryBtns.forEach(categoryBtn => {
 	categoryBtn.addEventListener("click", async () => {
-		wordContainer.innerHTML = "";//word一覧をクリア
+		wordList.innerHTML = "";//word一覧をクリア
 		clearWordDetail();//wordDetailの内容をクリア
 		const categoryId = categoryBtn.getAttribute("data-id");
 		selectedCategoryId = categoryId;
@@ -36,8 +37,10 @@ function clearWordDetail() {
 	wordName.innerHTML = "";
 	content.innerHTML = "";
 	category.innerHTML = "";
-	relatedWordList.innerHTML = "";
+	relatedWords.innerHTML = "";
 	editBtnContainer.innerHTML = "";
+	wordDetailContainer.classList.replace("wordDetailVisible","wordDetailHidden");
+
 }
 //カテゴリに属するword一覧を表示する
 async function showWordList(categoryId) {
@@ -49,12 +52,12 @@ async function showWordList(categoryId) {
 			if (words.length === 0) {
 				const msg = document.createElement("p");
 				msg.textContent = "単語がありません";
-				wordContainer.appendChild(msg);
+				wordList.appendChild(msg);
 				//カテゴリ削除ボタンを生成
 				const categoryDeleteBtn = document.createElement("button");
 				categoryDeleteBtn.textContent = "このカテゴリを削除";
 				categoryDeleteBtn.addEventListener("click", () => deleteCategory(selectedCategoryId));
-				wordContainer.appendChild(categoryDeleteBtn);
+				wordList.appendChild(categoryDeleteBtn);
 			}
 			//wordがある場合
 			const ul = document.createElement("ul");
@@ -70,13 +73,13 @@ async function showWordList(categoryId) {
 				li.addEventListener("click", () => showWordDetail(word.id));
 				ul.appendChild(li);
 			}
-			wordContainer.appendChild(ul);
+			wordList.appendChild(ul);
 		}
 	} catch (error) {
 		console.error(error);
 		const msg = document.createElement("p");
 		msg.textContent = "取得に失敗しました";
-		wordContainer.appendChild(msg);
+		wordList.appendChild(msg);
 	}
 }
 //カテゴリを削除する(カテゴリをクリックしてwordがなかった時)
@@ -107,7 +110,7 @@ async function showWordDetail(id) {
 			for (const relatedWord of wordDetail.relatedWords) {
 				const li = document.createElement("li");
 				li.textContent = relatedWord.wordName;
-				relatedWordList.appendChild(li);
+				relatedWords.appendChild(li);
 			}
 			// 編集ボタンを作成
 			const editBtn = document.createElement("button");
@@ -117,6 +120,7 @@ async function showWordDetail(id) {
 			});
 			editBtnContainer.appendChild(editBtn);
 		}
+		wordDetailContainer.classList.replace("wordDetailHidden","wordDetailVisible");
 	} catch (error) {
 		console.error(error);
 		alert("詳細情報の取得に失敗しました" + id);

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -17,22 +17,22 @@
 	<div th:if="${regist_cancel} != null" th:text="${regist_cancel}"></div>
 
 	<h3>カテゴリ一覧</h3>
-	<ul id="categoryTabs">
+	<ul id="categoryList">
 		<li th:each="category : ${categories}" th:object="${category}">
 			<button class="categoryBtn" th:text="*{name}" th:attr="data-id=*{id}"></button>
 		</li>
 	</ul>
 	<h3>word一覧</h3>
-	<div id="wordContainer">
+	<div id="wordList">
 	</div>
 	<h3>wordDetail</h3>
-	<div class="wordDetail">
+	<div class="wordDetailHidden">
 		<p>wordName:<span id="detail-wordName"></span></p>
 		<p>content:<span id="detail-content"></span></p>
 		<p>category:<span id="detail-category"></span></p>
 		<p>relatedWords:
 			<span id="detail-relatedWords">
-				<ul id="relatedWordList"></ul>
+				<ul id="relatedWords"></ul>
 			</span>
 		</p>
 		<div id="editBtnContainer"></div>


### PR DESCRIPTION
#### wordDetail の挙動
word_list.htmlにて、
カテゴリやwordが何も選択されていない状態では
wordDetailContainerはdisplay:noneで非表示の状態であり、
wordが選択されるとクラス名が切り替わり、
wordDetaiが表示されるように変更しました。

#### DB更新後のwordDetail表示
新規登録や編集が行われたwordの情報を、
更新処理後のリダイレクト先であるword_list.htmlにて
wordDetailに表示されるように変更しました。