### PR TITLE
Feature/#61 word list css

### DIFF
--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -1,13 +1,85 @@
 @charset "utf-8";
-.deleteBtnHidden{
-    display: none;
-}
-.deleteBtnVisible{
-    display: inline;
-}
-.wordDetailHidden{
+
+.deleteBtnHidden {
 	display: none;
 }
-.wordDetailVisible{
+
+.deleteBtnVisible {
 	display: inline;
+}
+
+.wordDetailHidden {
+	display: none;
+}
+
+.wordDetailVisible {
+	display: inline;
+}
+
+body {
+	margin: 0;
+	padding: 5%;
+	background-color: aliceblue;
+	box-sizing: border-box;
+}
+.mainContainer {
+	display: flex;
+}
+.categoryContainer,
+.wordListContainer,
+.wordDetailContainer{
+	margin:0%;
+	background-color: white;
+}
+
+
+.categoryContainer {
+	width: 15%;
+}
+
+.wordListContainer {
+	width: 20%;
+}
+
+.wordDetailContainer {
+	width: 60%;
+}
+
+.categoryContainer ul li {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	height: 40px;
+}
+
+.categoryContainer ul {
+	padding: 0%;
+}
+
+.categoryContainer ul li button {
+	display: block;
+	width: 100%;
+	height:100%;
+	padding: 10px;
+	text-align: left;
+	background-color: white;
+	border: none;
+	border-radius: 0%;
+	cursor: pointer;
+	font-size: 16px;
+}
+#wordList ul li:hover,
+.categoryBtn:hover {
+	background-color: #c0c0ff;
+}
+#wordList ul{
+	padding: 0%;
+}
+#wordList ul li{
+	list-style: none;
+	background-color: white;
+	padding: 0%;
+	cursor: pointer;
+	font-size: 16px;
+	height: 40px;
 }

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -1,71 +1,72 @@
 @charset "utf-8";
-body {
-	margin: 0;
-	padding: 5%;
-	background-color: #e5e5ee;
+:root {
+	--main-bg-color: #f4f4fa;
+	--main-text-color: #201f30;
+	--container-bg-color:white;
+	--line-color: #b0aec8;
+	--hover-bg-color: #201f30;
+	--hover-text-color: white;
+}
+* {
 	box-sizing: border-box;
-	color:#304755;
+	margin: 0;
+	padding: 0;
 }
-.deleteBtnHidden {
-	display: none;
+body {
+	background-color: var(--main-bg-color);
+	color: var(--main-text-color);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
-.deleteBtnVisible {
-	display: inline;
-}
-.wordDetailHidden {
-	display: none;
-}
-.wordDetailVisible {
-	display: inline;
-}
-.referenceHidden{
-	display: none;
-}
-.referenceVisible{
-	display: inline;
-}
-
+/* containers */
 .mainContainer {
 	display: flex;
+	background-color: var(--main-bg-color);
+	width: 95%;
+	max-width: 1100px;
+	margin:2%;
 }
-.categoryContainer,
-.wordListContainer,
-.wordDetailContainer{
-	margin:1px;
-	background-color: white;
+h4{
+	text-align: center;
+	border-bottom: 1px solid var(--main-bg-color);
 }
-.categoryContainer {
+#categoryOuter,
+#wordListOuter,
+#wordDetailOuter{
+	background-color: var(--container-bg-color);
+}
+#categoryOuter {
 	width: 25%;
 }
-.wordListContainer {
+#wordListOuter {
 	width: 25%;
-
 }
-.wordDetailContainer {
+#wordDetailOuter {
 	width: 50%;
+}
+.wordDetailContainer{
 	padding: 3%;
 }
-#wordList,
-#categoryList {
+/* categoryList, wordList */
+#categoryList, 
+.wordList{
 	padding: 0%;
-	border:1px solid white;
-
 }
-#wordList li,
-#categoryList li {
+#categoryList li,
+.wordList li{
 	list-style: none;
-	background-color: white;
 	margin: 0;
 	padding: 0;
 	height: 40px;
 }
-.wordBtn,
-.categoryBtn{
+.categoryBtn,
+.wordBtn{
 	width: 100%;
 	height:100%;
 	padding: 10px;
 	text-align: left;
-	background-color: white;
+	background-color:  var(--container-bg-color);
 	color:#304755;
 	border: none;
 	border-radius: 0%;
@@ -73,46 +74,141 @@ body {
 	font-size: 16px;
 }
 #categoryList li,
-#wordList li{
+.wordList li{
 	display: flex;
 }
-
 .wordBtn:hover,
 .categoryBtn:hover,
 .wordBtnSelected,
 .categoryBtnSelected {
-	background-color: #777499;
-	color: white;
-	border:1px solid #768994;
-
+	background-color: var(--hover-bg-color);
+	color:  var(--hover-text-color);
+	border:1px solid var(--hover-bg-color);
 }
 .categoryDeleteBtn,
 .wordDeleteBtn{
-	background-color: white;
+	width: 20%;
+	background-color:  var(--container-bg-color);
 	border: none;
 	color:#777499;
-	border:5px solid #777499;
+	border:2px solid var(--hover-bg-color);
 	font-size: 16px;
 	cursor: pointer;
 }
 .categoryDeleteBtn:hover,
 .wordDeleteBtn:hover{
 	background-color: #e5e5ee;
-	color:#474466;
-	border:5px solid #777499;
+	color:var(--main-text-color);
+	border:2px solid var(--hover-bg-color);
+}
+/* wordDetail */
+.wordDetailContainer div{
+	margin:0%;
+}
+.wordNameContainer{
+	display: flex;
+	justify-content: space-between;
 }
 
-#detail-content,
-#detailReference,
-#editBtnContainer{
-	margin:3%;
+.wordName{
+	font-size:32px;
 }
-#detail-wordName{
-	font-size: 28px;
+.content{
+	font-size: 16px;
+	border-top:2px solid var(--line-color);
+	border-bottom:2px solid var(--line-color);
+	padding:5%;
 }
-#categoryContainer{
+.category{
+	font-size: 12px;
+}
+.relatedWords{
 	font-size: 14px;
 }
-#relatedWords{
+.relatedWords ul{
 	display:inline-block;
+	list-style: none;
+	padding-left: 0;
+	
 }
+.relatedWords ul li{
+	display:inline-block;
+	padding-right:20px;
+}
+.editBtn:hover{
+	padding: 10px;
+	text-align: center;
+	background-color:var(--hover-bg-color);
+	border:2px solid var(--hover-bg-color);
+	color: var(--hover-text-color);
+	border-radius: 10%;
+	cursor: pointer;
+	font-size: 16px;
+}
+.editBtn{
+	padding: 10px;
+	text-align: center;
+	background-color:  var(--container-bg-color);
+	border:2px solid var(--hover-bg-color);
+	color:var(--hover-bg-color);
+	border-radius: 10%;
+	cursor: pointer;
+	font-size: 16px;
+}
+/* 新規登録 */
+
+#regist{
+	width:20%;
+	margin: 10px;
+}
+#regist a{
+	text-decoration: none;
+	background-color:var(--hover-bg-color);
+	color: var(--container-bg-color);
+	display: block;
+	padding:10px;
+	text-align: center;
+	
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -1,27 +1,23 @@
 @charset "utf-8";
-
-.deleteBtnHidden {
-	display: none;
-}
-
-.deleteBtnVisible {
-	display: inline;
-}
-
-.wordDetailHidden {
-	display: none;
-}
-
-.wordDetailVisible {
-	display: inline;
-}
-
 body {
 	margin: 0;
 	padding: 5%;
 	background-color: aliceblue;
 	box-sizing: border-box;
 }
+.deleteBtnHidden {
+	display: none;
+}
+.deleteBtnVisible {
+	display: inline;
+}
+.wordDetailHidden {
+	display: none;
+}
+.wordDetailVisible {
+	display: inline;
+}
+
 .mainContainer {
 	display: flex;
 }
@@ -31,32 +27,31 @@ body {
 	margin:0%;
 	background-color: white;
 }
-
-
 .categoryContainer {
 	width: 15%;
 }
-
 .wordListContainer {
-	width: 20%;
+	width: 15%;
 }
-
 .wordDetailContainer {
 	width: 60%;
 }
-
-.categoryContainer ul li {
+#wordList,
+#categoryList {
+	padding: 0%;
+}
+#wordList li,
+#categoryList li {
 	list-style: none;
+	background-color: white;
+	cursor: pointer;
 	margin: 0;
 	padding: 0;
 	height: 40px;
+	height: 40px;
 }
-
-.categoryContainer ul {
-	padding: 0%;
-}
-
-.categoryContainer ul li button {
+.wordBtn,
+.categoryBtn{
 	display: block;
 	width: 100%;
 	height:100%;
@@ -68,18 +63,7 @@ body {
 	cursor: pointer;
 	font-size: 16px;
 }
-#wordList ul li:hover,
+.wordBtn:hover,
 .categoryBtn:hover {
 	background-color: #c0c0ff;
-}
-#wordList ul{
-	padding: 0%;
-}
-#wordList ul li{
-	list-style: none;
-	background-color: white;
-	padding: 0%;
-	cursor: pointer;
-	font-size: 16px;
-	height: 40px;
 }

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -31,7 +31,7 @@ body {
 	width: 15%;
 }
 .wordListContainer {
-	width: 15%;
+	width: 25%;
 }
 .wordDetailContainer {
 	width: 60%;
@@ -48,11 +48,9 @@ body {
 	margin: 0;
 	padding: 0;
 	height: 40px;
-	height: 40px;
 }
 .wordBtn,
 .categoryBtn{
-	display: block;
 	width: 100%;
 	height:100%;
 	padding: 10px;
@@ -63,7 +61,18 @@ body {
 	cursor: pointer;
 	font-size: 16px;
 }
+#wordList li{
+	display: flex;
+}
+
 .wordBtn:hover,
 .categoryBtn:hover {
 	background-color: #c0c0ff;
 }
+
+.wordBtnSelected,
+.categoryBtnSelected {
+	background-color: #c0c0ff;
+}
+
+

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -2,8 +2,9 @@
 body {
 	margin: 0;
 	padding: 5%;
-	background-color: aliceblue;
+	background-color: #e5e5ee;
 	box-sizing: border-box;
+	color:#304755;
 }
 .deleteBtnHidden {
 	display: none;
@@ -17,6 +18,12 @@ body {
 .wordDetailVisible {
 	display: inline;
 }
+.referenceHidden{
+	display: none;
+}
+.referenceVisible{
+	display: inline;
+}
 
 .mainContainer {
 	display: flex;
@@ -24,27 +31,30 @@ body {
 .categoryContainer,
 .wordListContainer,
 .wordDetailContainer{
-	margin:0%;
+	margin:1px;
 	background-color: white;
 }
 .categoryContainer {
-	width: 15%;
+	width: 25%;
 }
 .wordListContainer {
 	width: 25%;
+
 }
 .wordDetailContainer {
-	width: 60%;
+	width: 50%;
+	padding: 3%;
 }
 #wordList,
 #categoryList {
 	padding: 0%;
+	border:1px solid white;
+
 }
 #wordList li,
 #categoryList li {
 	list-style: none;
 	background-color: white;
-	cursor: pointer;
 	margin: 0;
 	padding: 0;
 	height: 40px;
@@ -56,23 +66,53 @@ body {
 	padding: 10px;
 	text-align: left;
 	background-color: white;
+	color:#304755;
 	border: none;
 	border-radius: 0%;
 	cursor: pointer;
 	font-size: 16px;
 }
+#categoryList li,
 #wordList li{
 	display: flex;
 }
 
 .wordBtn:hover,
-.categoryBtn:hover {
-	background-color: #c0c0ff;
-}
-
+.categoryBtn:hover,
 .wordBtnSelected,
 .categoryBtnSelected {
-	background-color: #c0c0ff;
+	background-color: #777499;
+	color: white;
+	border:1px solid #768994;
+
+}
+.categoryDeleteBtn,
+.wordDeleteBtn{
+	background-color: white;
+	border: none;
+	color:#777499;
+	border:5px solid #777499;
+	font-size: 16px;
+	cursor: pointer;
+}
+.categoryDeleteBtn:hover,
+.wordDeleteBtn:hover{
+	background-color: #e5e5ee;
+	color:#474466;
+	border:5px solid #777499;
 }
 
-
+#detail-content,
+#detailReference,
+#editBtnContainer{
+	margin:3%;
+}
+#detail-wordName{
+	font-size: 28px;
+}
+#categoryContainer{
+	font-size: 14px;
+}
+#relatedWords{
+	display:inline-block;
+}

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -1,5 +1,6 @@
 
 let selectedCategoryId = null;//現在表示されているカテゴリのidを保持する用
+const wordListContainer = document.querySelector(".wordListContainer");
 const wordList = document.getElementById("wordList");
 const categoryBtns = document.querySelectorAll(".categoryBtn");
 const wordName = document.getElementById("detail-wordName");
@@ -24,7 +25,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 	const params = new URLSearchParams(window.location.search);
 	const categoryId = params.get("categoryId");
 	const wordId = params.get("id");
-	console.log(categoryId,wordId);
+	console.log(categoryId, wordId);
 	if (categoryId) {
 		await showWordList(categoryId);
 	}
@@ -39,7 +40,7 @@ function clearWordDetail() {
 	category.innerHTML = "";
 	relatedWords.innerHTML = "";
 	editBtnContainer.innerHTML = "";
-	wordDetailContainer.classList.replace("wordDetailVisible","wordDetailHidden");
+	wordDetailContainer.classList.replace("wordDetailVisible", "wordDetailHidden");
 
 }
 //カテゴリに属するword一覧を表示する
@@ -52,36 +53,38 @@ async function showWordList(categoryId) {
 			if (words.length === 0) {
 				const msg = document.createElement("p");
 				msg.textContent = "単語がありません";
-				wordList.appendChild(msg);
+				wordListContainer.appendChild(msg);
 				//カテゴリ削除ボタンを生成
 				const categoryDeleteBtn = document.createElement("button");
 				categoryDeleteBtn.textContent = "このカテゴリを削除";
 				categoryDeleteBtn.addEventListener("click", () => deleteCategory(selectedCategoryId));
-				wordList.appendChild(categoryDeleteBtn);
-				
+				wordListContainer.appendChild(categoryDeleteBtn);
+
 				return;
 			}
 			//wordがある場合
-			const ul = document.createElement("ul");
 			for (const word of words) {
 				const li = document.createElement("li");
-				li.textContent = word.wordName;
+				const wordButton = document.createElement("button");
+				wordButton.textContent = word.wordName;
+				wordButton.classList.add("wordBtn");
+				li.appendChild(wordButton);
 				//word削除ボタンの作成
 				const wordDeleteBtn = document.createElement("button");
 				wordDeleteBtn.textContent = "削除";
+				wordDeleteBtn.classList.add("wordDeleteBtn");
 				wordDeleteBtn.addEventListener("click", (e) => deleteWord(e, word.id, li))
 				li.appendChild(wordDeleteBtn);
 				//詳細表示
 				li.addEventListener("click", () => showWordDetail(word.id));
-				ul.appendChild(li);
+				wordList.appendChild(li);
 			}
-			wordList.appendChild(ul);
 		}
 	} catch (error) {
 		console.error(error);
 		const msg = document.createElement("p");
 		msg.textContent = "取得に失敗しました";
-		wordList.appendChild(msg);
+		wordListContainer.appendChild(msg);
 	}
 }
 //カテゴリを削除する(カテゴリをクリックしてwordがなかった時)
@@ -122,7 +125,7 @@ async function showWordDetail(id) {
 			});
 			editBtnContainer.appendChild(editBtn);
 		}
-		wordDetailContainer.classList.replace("wordDetailHidden","wordDetailVisible");
+		wordDetailContainer.classList.replace("wordDetailHidden", "wordDetailVisible");
 	} catch (error) {
 		console.error(error);
 		alert("詳細情報の取得に失敗しました" + id);

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -1,110 +1,187 @@
-
-let selectedCategoryId = null;//現在表示されているカテゴリのidを保持する用
+//新規登録や編集を実行後、対象wordのカテゴリとwordNameが選択された状態にする(色がつく)
+window.addEventListener("DOMContentLoaded", async () => {
+	const params = new URLSearchParams(window.location.search);
+	const categoryId = params.get("categoryId");
+	const wordId = params.get("id");
+	if (categoryId) {
+		setCategorySelection(categoryId);
+		await showWordList(categoryId);
+	}
+	if (wordId) {
+		setWordSelection(wordId)
+		await showWordDetail(wordId);
+	}
+})
+// 各コンテナ
+const mainConteiner = document.querySelector(".mainContainer");
+const categoryContainer = document.querySelector(".categoryContainer");
 const wordListContainer = document.querySelector(".wordListContainer");
-const wordList = document.getElementById("wordList");
-const wordListNullMsg = document.getElementById("wordListNullMsg")
+const wordDetailContainer = document.querySelector(".wordDetailContainer");
+// カテゴリ
+let currentCategoryId = null;
+const categoryList = document.querySelector(".categoryList");
 const categoryBtns = document.querySelectorAll(".categoryBtn");
-const wordName = document.getElementById("detail-wordName");
-const content = document.getElementById("detail-content");
-const category = document.getElementById("detail-category");
-const relatedWords = document.getElementById("detail-relatedWords");
-const reference = document.querySelector(".reference");
-const relatedWordList = document.getElementById("relatedWordList");
-const editBtnContainer = document.getElementById("editBtnContainer");
-const wordDetailContainer = document.querySelector(".wordDetailHidden");
 
-//カテゴリをクリック
 categoryBtns.forEach(categoryBtn => {
 	categoryBtn.addEventListener("click", async () => {
-		//もろもろクリアする
-		document.querySelectorAll(".categoryDeleteBtn").forEach(btn => btn.remove());
-		document.querySelectorAll(".categoryBtnSelected").forEach(btn => btn.classList.remove("categoryBtnSelected"));
-		wordList.innerHTML = "";
-		wordListNullMsg.innerHTML = "";
-		clearWordDetail();
-		//現在選択中のcategoryIdを記憶
-		const categoryId = categoryBtn.getAttribute("data-id");
-		selectedCategoryId = categoryId;
+		//選択中カテゴリの設定
+		clearCategorySelection();
+		currentCategoryId = categoryBtn.getAttribute("data-id");
 		categoryBtn.classList.add("categoryBtnSelected");
-		//wordList表示
-		showWordList(categoryId, categoryBtn);
+		//単語一覧を表示
+		wordListContainer.innerHTML = "";
+		showWordList(currentCategoryId);
 	})
-});
-
-//wordDetailの項目をクリア
-function clearWordDetail() {
-	wordName.innerHTML = "";
-	content.innerHTML = "";
-	category.innerHTML = "";
-	relatedWordList.innerHTML = "";
-	editBtnContainer.innerHTML = "";
-	wordDetailContainer.classList.replace("wordDetailVisible", "wordDetailHidden");
-	if (reference) {
-		reference.classList.replace("referenceVisible", "referenceHidden");
-	}
+})
+// カテゴリ選択をクリア
+function clearCategorySelection() {
+	document.querySelectorAll(".categoryDeleteBtn").forEach(btn => btn.remove());
+	document.querySelectorAll(".categoryBtnSelected").forEach(btn => btn.classList.remove("categoryBtnSelected"));
 }
-//wordListの表示
-async function showWordList(categoryId, categoryBtn) {
+// 選択中カテゴリの色変更
+function setCategorySelection(categoryId) {
+	[...categoryBtns].find(btn => btn.getAttribute("data-id") === categoryId).classList.add("categoryBtnSelected");
+}
+// 選択中wordの色変更
+function setWordSelection(wordId) {
+	const wordBtns = document.querySelectorAll(".wordBtn");
+	[...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") === wordId)
+		.classList.add("wordBtnSelected");
+}
+
+// wordList表示
+async function showWordList(categoryId) {
 	try {
 		const res = await fetch(`/api/words?categoryId=${categoryId}`);
 		if (res.ok) {
 			const words = await res.json();
-			//wordがない場合
+			// 単語なしの場合
 			if (words.length === 0) {
-				const msg = document.createElement("p");
+				// 「単語なし」メーセージ
+				const msg = document.createElement("span");
 				msg.textContent = "単語がありません";
-				wordListNullMsg.appendChild(msg);
-				//カテゴリ削除ボタンを生成
+				wordListContainer.appendChild(msg);
+				// カテゴリ削除ボタン
 				const categoryDeleteBtn = document.createElement("button");
 				categoryDeleteBtn.classList.add("categoryDeleteBtn");
 				const span = document.createElement("span");
-				span.classList.add("bi", "bi-trash3-fill");
+				span.classList.add("bi-trash3-fill");
 				categoryDeleteBtn.appendChild(span);
-				categoryDeleteBtn.addEventListener("click", () => deleteCategory(selectedCategoryId));
-				categoryBtn.after(categoryDeleteBtn);
+				//カテゴリボタンの横にカテゴリ削除ボタンを追加
+				[...categoryBtns].find(btn => btn.getAttribute("data-id") === categoryId).after(categoryDeleteBtn);
+				categoryDeleteBtn.addEventListener("click", (event) => deleteCategory(event, categoryId))
 
-				return;
-			}
-			//wordがある場合
-			for (const word of words) {
-				const li = document.createElement("li");
-				const wordButton = document.createElement("button");
-				wordButton.textContent = word.wordName;
-				wordButton.classList.add("wordBtn");
-				li.appendChild(wordButton);
-				//削除ボタンと詳細表示
-				wordButton.addEventListener("click", () => {
-					//削除ボタンをいったん全削除
-					document.querySelectorAll(".wordDeleteBtn").forEach(btn => btn.remove());
-					document.querySelectorAll(".wordBtnSelected").forEach(btn => btn.classList.remove("wordBtnSelected"));
-
-					wordButton.classList.add("wordBtnSelected");
-					//word削除ボタンの作成
-					const currentWordDeleteBtn = document.createElement("button");
+				// 単語ありの場合
+			} else {
+				const wordList = document.createElement("ul");
+				wordList.classList.add("wordList");
+				for (const word of words) {
+					const li = document.createElement("li");
+					// 単語ボタン
+					const wordBtn = document.createElement("button");
+					wordBtn.setAttribute("data-id", word.id);
+					wordBtn.textContent = word.wordName;
+					wordBtn.classList.add("wordBtn");
+					li.appendChild(wordBtn);
+					// 単語削除ボタン <button class="categoryDeleteBtn"><span class="bi-trash3-fill"></span></button>
+					const wordDeleteBtn = document.createElement("button");
+					wordDeleteBtn.classList.add("wordDeleteBtn");
 					const span = document.createElement("span");
-					span.classList.add("bi", "bi-trash3-fill");
-					currentWordDeleteBtn.appendChild(span);
-					currentWordDeleteBtn.classList.add("wordDeleteBtn");
-					currentWordDeleteBtn.addEventListener("click", (e) => deleteWord(e, word.id, li))
-					li.appendChild(currentWordDeleteBtn);
+					span.classList.add("bi-trash3-fill");
+					wordDeleteBtn.appendChild(span);
 
-					//wordDetail表示
-					showWordDetail(word.id)
-				});
-				wordList.appendChild(li);
+					wordDeleteBtn.addEventListener("click", (event) => {
+						wordDetailContainer.innerHTML = "";
+						deleteWord(event, word.id, li)
+					});
+
+					wordBtn.addEventListener("click", () => {
+						wordDetailContainer.innerHTML = "";
+						document.querySelectorAll(".wordBtnSelected").forEach(btn => btn.classList.remove("wordBtnSelected"))
+						document.querySelectorAll(".wordDeleteBtn").forEach(btn => btn.remove());
+						wordBtn.classList.add("wordBtnSelected");
+						li.appendChild(wordDeleteBtn);
+
+						showWordDetail(word.id);
+					})
+					li.appendChild(wordBtn);
+					wordList.appendChild(li);
+				}
+				wordListContainer.appendChild(wordList);
 			}
 		}
 	} catch (error) {
-		console.error(error);
+		console.log(error);
 		const msg = document.createElement("p");
 		msg.textContent = "取得に失敗しました";
 		wordListContainer.appendChild(msg);
 	}
 }
-//カテゴリの削除
-async function deleteCategory(id) {
+//wordDetail表示
+async function showWordDetail(wordId) {
 	try {
-		const res = await fetch(`/api/categories/${id}`, { method: "DELETE" });
+		const res = await fetch(`/api/words/${wordId}`);
+		if (res.ok) {
+			const wordDetail = await res.json();
+
+			const wordNameContainer = document.createElement("div");
+			wordNameContainer.classList.add("wordNameContainer");
+			//単語名
+			const wordName = document.createElement("div");
+			wordName.classList.add("wordName");
+			wordName.textContent = wordDetail.wordName;
+			
+			//編集ボタン
+			const editBtn = document.createElement("button");
+			editBtn.classList.add("editBtn");
+			const span = document.createElement("span");
+			span.classList.add("bi-pencil-square");
+			editBtn.append(span);
+			editBtn.addEventListener("click", () => {
+				location.href = `/words/${wordId}/editForm`;
+			})
+			wordNameContainer.append(wordName,editBtn);
+			//カテゴリ
+			const categoryContainer = document.createElement("div");
+			categoryContainer.classList.add("category");
+
+			const categoryLabel = document.createElement("span");
+			categoryLabel.textContent = "カテゴリ：";
+			const category = document.createElement("span");
+			category.textContent = wordDetail.category.name;
+
+			categoryContainer.append(categoryLabel, category);
+			//説明文
+			const content = document.createElement("div");
+			content.classList.add("content");
+			content.textContent = wordDetail.content;
+			
+			wordDetailContainer.append(wordNameContainer,categoryContainer,content);
+			//関連語
+			if (wordDetail.relatedWords && wordDetail.relatedWords.length > 0) {
+				const relatedWordsContainer = document.createElement("div");
+				relatedWordsContainer.classList.add("relatedWords")
+				const reference = document.createElement("span");
+				reference.textContent = "参照：";
+				const relatedWords = document.createElement("ul");
+				for (const word of wordDetail.relatedWords) {
+					const li = document.createElement("li");
+					li.textContent = word.wordName;
+					relatedWords.appendChild(li);
+				}
+				relatedWordsContainer.append(reference, relatedWords);
+				wordDetailContainer.appendChild(relatedWordsContainer);
+			}
+		}
+	} catch (error) {
+		console.log(error)
+	}
+}
+//category削除
+async function deleteCategory(event, categoryId) {
+	event.stopPropagation();
+	try {
+		const res = await fetch(`/api/categories/${categoryId}`, { method: "DELETE" });
 		if (res.ok) {
 			location.reload();
 		} else {
@@ -115,49 +192,11 @@ async function deleteCategory(id) {
 		alert("通信エラーが発生しました");
 	}
 }
-//word詳細の表示
-async function showWordDetail(id) {
-	clearWordDetail();
+//word削除
+async function deleteWord(event, wordId, li) {
+	event.stopPropagation();
 	try {
-		const res = await fetch(`/api/words/${id}`);
-		if (res.ok) {
-			const wordDetail = await res.json();
-			wordName.textContent = wordDetail.wordName;
-			content.textContent = wordDetail.content;
-			category.textContent = wordDetail.category.name;
-
-			if (wordDetail.relatedWords && wordDetail.relatedWords.length > 0) {
-				if (reference) {
-					reference.classList.replace("referenceHidden", "referenceVisible");
-				}
-				for (const relatedWord of wordDetail.relatedWords) {
-					const li = document.createElement("li");
-					li.textContent = relatedWord.wordName;
-					relatedWordList.appendChild(li);
-				}
-			}
-			// 編集ボタンを作成
-			const editBtn = document.createElement("button");
-			editBtn.textContent = "編集";
-			const span = document.createElement("span");
-			span.classList.add("bi", "bi-pencil-square");
-			editBtn.appendChild(span);
-			editBtn.addEventListener("click", () => {
-				location.href = `/words/${wordDetail.id}/editForm`;
-			});
-			editBtnContainer.appendChild(editBtn);
-		}
-		wordDetailContainer.classList.replace("wordDetailHidden", "wordDetailVisible");
-	} catch (error) {
-		console.error(error);
-		alert("詳細情報の取得に失敗しました" + id);
-	}
-}
-//wordの削除
-async function deleteWord(e, id, li) {
-	e.stopPropagation();
-	try {
-		const res = await fetch(`/api/words/${id}`, { method: "DELETE" });
+		const res = await fetch(`/api/words/${wordId}`, { method: "DELETE" });
 		if (res.ok) {
 			li.remove();
 			clearWordDetail()
@@ -168,19 +207,36 @@ async function deleteWord(e, id, li) {
 		console.log(error);
 	}
 }
-//編集画面から戻ってきた時に前画面の内容を表示させる
-window.addEventListener("DOMContentLoaded", async () => {
-	const params = new URLSearchParams(window.location.search);
-	const categoryId = params.get("categoryId");
-	const wordId = params.get("id");
-	console.log(categoryId, wordId);
-	if (categoryId) {
-		await showWordList(categoryId);
-	}
-	if (wordId) {
-		await showWordDetail(wordId);
-	}
-});
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -7,7 +7,9 @@ const categoryBtns = document.querySelectorAll(".categoryBtn");
 const wordName = document.getElementById("detail-wordName");
 const content = document.getElementById("detail-content");
 const category = document.getElementById("detail-category");
-const relatedWords = document.getElementById("relatedWords");
+const relatedWords = document.getElementById("detail-relatedWords");
+const reference = document.querySelector(".reference");
+const relatedWordList = document.getElementById("relatedWordList");
 const editBtnContainer = document.getElementById("editBtnContainer");
 const wordDetailContainer = document.querySelector(".wordDetailHidden");
 
@@ -15,17 +17,17 @@ const wordDetailContainer = document.querySelector(".wordDetailHidden");
 categoryBtns.forEach(categoryBtn => {
 	categoryBtn.addEventListener("click", async () => {
 		//もろもろクリアする
+		document.querySelectorAll(".categoryDeleteBtn").forEach(btn => btn.remove());
 		document.querySelectorAll(".categoryBtnSelected").forEach(btn => btn.classList.remove("categoryBtnSelected"));
 		wordList.innerHTML = "";
 		wordListNullMsg.innerHTML = "";
-		
 		clearWordDetail();
 		//現在選択中のcategoryIdを記憶
 		const categoryId = categoryBtn.getAttribute("data-id");
 		selectedCategoryId = categoryId;
 		categoryBtn.classList.add("categoryBtnSelected");
 		//wordList表示
-		showWordList(categoryId);
+		showWordList(categoryId, categoryBtn);
 	})
 });
 
@@ -34,12 +36,15 @@ function clearWordDetail() {
 	wordName.innerHTML = "";
 	content.innerHTML = "";
 	category.innerHTML = "";
-	relatedWords.innerHTML = "";
+	relatedWordList.innerHTML = "";
 	editBtnContainer.innerHTML = "";
 	wordDetailContainer.classList.replace("wordDetailVisible", "wordDetailHidden");
+	if (reference) {
+		reference.classList.replace("referenceVisible", "referenceHidden");
+	}
 }
 //wordListの表示
-async function showWordList(categoryId) {
+async function showWordList(categoryId, categoryBtn) {
 	try {
 		const res = await fetch(`/api/words?categoryId=${categoryId}`);
 		if (res.ok) {
@@ -51,9 +56,12 @@ async function showWordList(categoryId) {
 				wordListNullMsg.appendChild(msg);
 				//カテゴリ削除ボタンを生成
 				const categoryDeleteBtn = document.createElement("button");
-				categoryDeleteBtn.textContent = "このカテゴリを削除";
+				categoryDeleteBtn.classList.add("categoryDeleteBtn");
+				const span = document.createElement("span");
+				span.classList.add("bi", "bi-trash3-fill");
+				categoryDeleteBtn.appendChild(span);
 				categoryDeleteBtn.addEventListener("click", () => deleteCategory(selectedCategoryId));
-				wordListNullMsg.appendChild(categoryDeleteBtn);
+				categoryBtn.after(categoryDeleteBtn);
 
 				return;
 			}
@@ -69,14 +77,17 @@ async function showWordList(categoryId) {
 					//削除ボタンをいったん全削除
 					document.querySelectorAll(".wordDeleteBtn").forEach(btn => btn.remove());
 					document.querySelectorAll(".wordBtnSelected").forEach(btn => btn.classList.remove("wordBtnSelected"));
+
 					wordButton.classList.add("wordBtnSelected");
 					//word削除ボタンの作成
 					const currentWordDeleteBtn = document.createElement("button");
-					currentWordDeleteBtn.textContent = "削除";
+					const span = document.createElement("span");
+					span.classList.add("bi", "bi-trash3-fill");
+					currentWordDeleteBtn.appendChild(span);
 					currentWordDeleteBtn.classList.add("wordDeleteBtn");
 					currentWordDeleteBtn.addEventListener("click", (e) => deleteWord(e, word.id, li))
 					li.appendChild(currentWordDeleteBtn);
-					
+
 					//wordDetail表示
 					showWordDetail(word.id)
 				});
@@ -115,14 +126,22 @@ async function showWordDetail(id) {
 			content.textContent = wordDetail.content;
 			category.textContent = wordDetail.category.name;
 
-			for (const relatedWord of wordDetail.relatedWords) {
-				const li = document.createElement("li");
-				li.textContent = relatedWord.wordName;
-				relatedWords.appendChild(li);
+			if (wordDetail.relatedWords && wordDetail.relatedWords.length > 0) {
+				if (reference) {
+					reference.classList.replace("referenceHidden", "referenceVisible");
+				}
+				for (const relatedWord of wordDetail.relatedWords) {
+					const li = document.createElement("li");
+					li.textContent = relatedWord.wordName;
+					relatedWordList.appendChild(li);
+				}
 			}
 			// 編集ボタンを作成
 			const editBtn = document.createElement("button");
 			editBtn.textContent = "編集";
+			const span = document.createElement("span");
+			span.classList.add("bi", "bi-pencil-square");
+			editBtn.appendChild(span);
 			editBtn.addEventListener("click", () => {
 				location.href = `/words/${wordDetail.id}/editForm`;
 			});

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -10,9 +10,12 @@
 </head>
 
 <body>
-	<a th:href="@{/showWordForm}">word新規登録画面へ</a>
-
 	<h1>単語帳</h1>
+
+	<div id="regist">
+		<a th:href="@{/showWordForm}"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
+	</div>
+
 	<div th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
 	<div th:if="${delete_ok} != null" th:text="${delete_ok}"></div>
 	<div th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
@@ -20,41 +23,30 @@
 
 	<div class="mainContainer">
 		<!-- categoryList -->
-		<div class="categoryContainer">
-			<h3>カテゴリ</h3>
-			<ul id="categoryList">
-				<li th:each="category : ${categories}" th:object="${category}">
-					<button class="categoryBtn" th:text="*{name}" th:attr="data-id=*{id}"></button>
-				</li>
-			</ul>
+		<div id="categoryOuter">
+			<h4>カテゴリ</h4>
+			<div class="categoryContainer">
+				<ul id="categoryList">
+					<li th:each="category : ${categories}" th:object="${category}">
+						<button class="categoryBtn" th:text="*{name}" th:attr="data-id=*{id}"></button>
+					</li>
+				</ul>
+			</div>
 		</div>
 
 		<!-- wordList -->
-		<div class="wordListContainer">
-			<h3>単語</h3>
-			<ul id="wordList">
-			</ul>
-			<div id="wordListNullMsg"></div>
+		<div id="wordListOuter">
+			<h4>単語</h4>
+			<div class="wordListContainer">
+			</div>
 		</div>
 
 		<!-- wordDetail -->
-		<div class="wordDetailContainer">
-			<div class="wordDetailHidden">
-				<div id="detail-wordName"></div>
-				<div id="categoryContainer">
-					<span>カテゴリ:</span>
-					<span id="detail-category"></span>
-				</div>
+		<div id="wordDetailOuter">
+			<h4>内容</h4>
+			<div class="wordDetailContainer">
 			</div>
-			<div id="detail-content"></div>
-			<div id="detail-relatedWords">
-				<span class="reference referenceHidden">参照：</span>
-				<ul id="relatedWordList"></ul>
-			</div>
-			<div id="editBtnContainer"></div>
 		</div>
-	</div>
-	</div>
 </body>
 
 </html>

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
@@ -7,12 +6,13 @@
 	<title>単語一覧</title>
 	<link rel="stylesheet" th:href="@{/css/word_list.css}">
 	<script th:src="@{/js/word_list.js}" defer></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 </head>
 
 <body>
 	<a th:href="@{/showWordForm}">word新規登録画面へ</a>
 
-	<h1>word一覧</h1>
+	<h1>単語帳</h1>
 	<div th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
 	<div th:if="${delete_ok} != null" th:text="${delete_ok}"></div>
 	<div th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
@@ -21,7 +21,7 @@
 	<div class="mainContainer">
 		<!-- categoryList -->
 		<div class="categoryContainer">
-			<h3>カテゴリ一覧</h3>
+			<h3>カテゴリ</h3>
 			<ul id="categoryList">
 				<li th:each="category : ${categories}" th:object="${category}">
 					<button class="categoryBtn" th:text="*{name}" th:attr="data-id=*{id}"></button>
@@ -31,27 +31,29 @@
 
 		<!-- wordList -->
 		<div class="wordListContainer">
-			<h3>word一覧</h3>
+			<h3>単語</h3>
 			<ul id="wordList">
 			</ul>
 			<div id="wordListNullMsg"></div>
 		</div>
-		
+
 		<!-- wordDetail -->
 		<div class="wordDetailContainer">
-			<h3>wordDetail</h3>
 			<div class="wordDetailHidden">
-				<p>wordName:<span id="detail-wordName"></span></p>
-				<p>content:<span id="detail-content"></span></p>
-				<p>category:<span id="detail-category"></span></p>
-				<p>relatedWords:
-					<span id="detail-relatedWords">
-						<ul id="relatedWords"></ul>
-					</span>
-				</p>
-				<div id="editBtnContainer"></div>
+				<div id="detail-wordName"></div>
+				<div id="categoryContainer">
+					<span>カテゴリ:</span>
+					<span id="detail-category"></span>
+				</div>
 			</div>
+			<div id="detail-content"></div>
+			<div id="detail-relatedWords">
+				<span class="reference referenceHidden">参照：</span>
+				<ul id="relatedWordList"></ul>
+			</div>
+			<div id="editBtnContainer"></div>
 		</div>
+	</div>
 	</div>
 </body>
 

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
@@ -10,32 +11,46 @@
 
 <body>
 	<a th:href="@{/showWordForm}">word新規登録画面へ</a>
+
 	<h1>word一覧</h1>
 	<div th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
 	<div th:if="${delete_ok} != null" th:text="${delete_ok}"></div>
 	<div th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
 	<div th:if="${regist_cancel} != null" th:text="${regist_cancel}"></div>
 
-	<h3>カテゴリ一覧</h3>
-	<ul id="categoryList">
-		<li th:each="category : ${categories}" th:object="${category}">
-			<button class="categoryBtn" th:text="*{name}" th:attr="data-id=*{id}"></button>
-		</li>
-	</ul>
-	<h3>word一覧</h3>
-	<div id="wordList">
-	</div>
-	<h3>wordDetail</h3>
-	<div class="wordDetailHidden">
-		<p>wordName:<span id="detail-wordName"></span></p>
-		<p>content:<span id="detail-content"></span></p>
-		<p>category:<span id="detail-category"></span></p>
-		<p>relatedWords:
-			<span id="detail-relatedWords">
-				<ul id="relatedWords"></ul>
-			</span>
-		</p>
-		<div id="editBtnContainer"></div>
+	<div class="mainContainer">
+		<!-- categoryList -->
+		<div class="categoryContainer">
+			<h3>カテゴリ一覧</h3>
+			<ul id="categoryList">
+				<li th:each="category : ${categories}" th:object="${category}">
+					<button class="categoryBtn" th:text="*{name}" th:attr="data-id=*{id}"></button>
+				</li>
+			</ul>
+		</div>
+
+		<!-- wordList -->
+		<div class="wordListContainer">
+			<h3>word一覧</h3>
+			<div id="wordList">
+			</div>
+		</div>
+		
+		<!-- wordDetail -->
+		<div class="wordListContainer">
+			<h3>wordDetail</h3>
+			<div class="wordDetailHidden">
+				<p>wordName:<span id="detail-wordName"></span></p>
+				<p>content:<span id="detail-content"></span></p>
+				<p>category:<span id="detail-category"></span></p>
+				<p>relatedWords:
+					<span id="detail-relatedWords">
+						<ul id="relatedWords"></ul>
+					</span>
+				</p>
+				<div id="editBtnContainer"></div>
+			</div>
+		</div>
 	</div>
 </body>
 

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -32,8 +32,8 @@
 		<!-- wordList -->
 		<div class="wordListContainer">
 			<h3>word一覧</h3>
-			<div id="wordList">
-			</div>
+			<ul id="wordList">
+			</ul>
 		</div>
 		
 		<!-- wordDetail -->

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -34,10 +34,11 @@
 			<h3>word一覧</h3>
 			<ul id="wordList">
 			</ul>
+			<div id="wordListNullMsg"></div>
 		</div>
 		
 		<!-- wordDetail -->
-		<div class="wordListContainer">
+		<div class="wordDetailContainer">
 			<h3>wordDetail</h3>
 			<div class="wordDetailHidden">
 				<p>wordName:<span id="detail-wordName"></span></p>


### PR DESCRIPTION
word_list.htmlのCSSを実装する中で
JSのコードに無理があったので
JSでDOMの追加方針を大幅に変更

【今まで】
wordDetailContainerの中に
あらかじめ<div id="wordName">...などを仕込むと、
追加はしやすいが削除に手間がかかる。

【変更後】
wordDetailContainerの中身は空で用意しておき、
タイトル・内容・見出しなどを含むすべてのコンテンツを全て動的に生成することで
単語の切り替え時は innerHTML = "";  で一括削除できるように変更。