### PR TITLE
Feature/#63 regist form css

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
@@ -46,7 +46,8 @@ public class WordFormValidator implements Validator {
 			//   wordNameによる検索で既存だった  かつ  既存のwordを編集の時
 			//   ( 編集対象のwordは wordNameによる検索で見つかったword と同じidである必要がある)
 			if (wordForm.getId() == null || !wordForm.getId().equals(existingWord.getId())) {
-				errors.rejectValue("wordName", null, wordForm.getWordName() + "はすでに登録されています");
+//				errors.rejectValue("wordName", null, wordForm.getWordName() + "は既に登録されています");
+				errors.rejectValue("wordName", null, "はすでに登録されています");
 			}
 		}
 		//categoryIdとcategoryNameの両方に入力があればエラー

--- a/KnowledgeMap/src/main/resources/static/css/common.css
+++ b/KnowledgeMap/src/main/resources/static/css/common.css
@@ -1,0 +1,21 @@
+@charset "UTF-8";
+:root {
+	--main-bg-color: #f4f4fa;
+	--main-text-color: #201f30;
+	--container-bg-color:white;
+	--line-color: #b0aec8;
+	--hover-bg-color: #201f30;
+	--hover-text-color: white;
+}
+* {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+body {
+	background-color: var(--main-bg-color);
+	color: var(--main-text-color);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}

--- a/KnowledgeMap/src/main/resources/static/css/common.css
+++ b/KnowledgeMap/src/main/resources/static/css/common.css
@@ -1,21 +1,41 @@
 @charset "UTF-8";
+
 :root {
 	--main-bg-color: #f4f4fa;
 	--main-text-color: #201f30;
-	--container-bg-color:white;
+	--container-bg-color: white;
+	--hover-bg-color: #353e60;
 	--line-color: #b0aec8;
-	--hover-bg-color: #201f30;
-	--hover-text-color: white;
+
 }
+
 * {
 	box-sizing: border-box;
 	margin: 0;
 	padding: 0;
 }
+
 body {
 	background-color: var(--main-bg-color);
 	color: var(--main-text-color);
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+}
+
+button,
+.button {
+	background-color:  var(--main-text-color);
+	color: var(--container-bg-color);
+	border-radius: 5px;
+	border: 1px solid var(--main-text-color);
+	
+	text-decoration: none;
+	text-align: center;	
+
+
+}
+button:hover,
+.button:hover{
+	background-color: var(--hover-bg-color)
 }

--- a/KnowledgeMap/src/main/resources/static/css/regist_form.css
+++ b/KnowledgeMap/src/main/resources/static/css/regist_form.css
@@ -1,16 +1,7 @@
 @charset "UTF-8";
-:root {
-	--main-bg-color: #f4f4fa;
-	--main-text-color: #201f30; 
-	--container-bg-color: #ffffff;
-	--line-color: #b0aec8; 
-	--hover-bg-color: #201f30;
-	--hover-text-color: white;
-	font-size: 16px;
-}
-
 h1{
 	font-size: 2rem;
+	padding:2rem;
 }
 /* form全体 */
 .registForm{
@@ -20,14 +11,15 @@ h1{
 	background-color: var(--container-bg-color);
 	border: 1px solid var(--line-color);
 	border-radius: 10px;
-	padding: 1%;
+	padding: 2rem;
 }
 /* formの1行分 */
 .row{
 	display:grid;
-	grid-template-columns: 20% 1fr;
-	padding: 1% 0%;
+	grid-template-columns: 15% 1fr;
+	padding: 0.2rem 0;
 	align-items: start;
+	column-gap: 2rem;
 }
 /* formの1行の右側 */
 .row label{
@@ -38,56 +30,34 @@ h1{
 }
 /* formの1行の左側 */
 .inputContainer{
-	padding:0px 5px;
+	padding:0 0.3rem;
+	width:100%;
 }
 /* error */
 .error {
-	margin-top: 4px;
+	margin-bottom: 0.5rem;
 	color: red;
-	font-size: 0.9em;
-	min-height: 1.2em;
+	font-size: 0.8rem;
+	min-height: 0.9rem;
 }
 .error span:empty::after {
 	content: " ";
 	display: inline-block;
 	visibility: hidden;
 }
-#existingWordLink {
-	color: red;
-	cursor: pointer;
-	transition: color 0.2s;
-	text-decoration: none;
-}
 
-#existingWordLink:hover {
-	color: rgb(145, 32, 22);
-}
-.existingWordDetail{
-	display: none;
-	
-	margin-top: 10px;
-	padding: 16px;
-	border: 1px solid var(--line-color);
-	border-radius: 12px;
-	background-color: var(--main-bg-color);
-	width: 80%;
-	box-sizing: border-box;
-}
-.existingWordDetailVisible{
-	display:block;
-}
 /* category */
 #categoryInputContainer{
 	display:grid;
 	grid-template-columns: 1fr 1fr;
-	column-gap: 20px;
-	width: 80%;
+	column-gap: 2rem;
+	width: 100%;
 }
 #categoryId,
 #categoryName{
-	padding: 2px;
+	padding: 0.1rem;
 	border: 1px solid var(--line-color);
-	border-radius: 4px;
+	border-radius: 5px;
 	font-size: 0.9rem;
 	width: 100%;
 }
@@ -99,45 +69,42 @@ h1{
 #wordName,
 #content,
 #relatedWordIds {
-	padding: 2px;
+	padding: 0.1rem;
 	border: 1px solid var(--line-color);
-	border-radius: 4px;
+	border-radius: 5px;
 	font-size: 0.9rem;
-	width: 80%;
+	width: 100%;
 }
 #content {
-	min-height: 200px;
+	min-height: 10rem;
 	resize: vertical;
 }
-/* 登録確認ボタン */
-#registConfirmBtn {
-	width: 300px;
-	background-color: var(--hover-bg-color);
-	color: var(--hover-text-color);
-	border: none;
-	padding: 10px 24px;
-	border-radius: 6px;
-	display: block;
-	margin:  0 auto;
-}
-
-#registConfirmBtn:hover {
-	background-color: #000;
-}
-
 /* 重複wordの表示 */
-.wordDetailContainer{
-	padding: 3%;
-	background-color: var(--container-bg-color);
+#existingWordLink {
+	color: red;
+	cursor: pointer;
+	text-decoration: none;
 }
-.wordDetailContainer div{
-	margin:0%;
+#existingWordLink:hover {
+	color: rgb(145, 32, 22);
+}
+.existingWordDetail{
+	display: none;	
+	margin-top: 0.5rem;
+	padding: 1rem;
+	border: 1px solid var(--line-color);
+	border-radius: 10px;
+	background-color: #f5dede;
+	color:var(--main-text-color);
+	width: 100%;
+}
+.existingWordDetailVisible{
+	display:block;
 }
 .wordNameContainer{
 	display: flex;
 	justify-content: space-between;
 }
-
 .wordName{
 	font-size: 2rem;
 }
@@ -145,7 +112,7 @@ h1{
 	font-size: 1rem;
 	border-top: 2px solid var(--line-color);
 	border-bottom: 2px solid var(--line-color);
-	padding: 20px;
+	padding: 2rem;
 }
 .category{
 	font-size: 0.7rem;
@@ -162,26 +129,30 @@ h1{
 	display:inline-block;
 	padding-right: 20px;
 }
-.editBtn:hover{
-	padding: 10px;
-	text-align: center;
-	background-color:var(--hover-bg-color);
-	border:2px solid var(--hover-bg-color);
-	color: var(--hover-text-color);
-	border-radius: 10%;
-	cursor: pointer;
-	font-size: 1rem;
-}
 .editBtn{
-	padding: 10px;
-	text-align: center;
-	background-color:  var(--line-color);
-	border:2px solid var(--line-color);
-	color:var(--container-bg-color);
-	border-radius: 10%;
-	cursor: pointer;
+	padding: 0.6rem;
 	font-size: 1rem;
 }
-
-
-
+/* 登録確認ボタン */
+#registConfirmBtn {
+	width: 30%;
+	padding: 0.6rem 1.5rem;
+	display: block;
+	margin:  0 auto;
+	font-size: 0.8rem;
+}
+/* 戻るボタン */
+#return{
+	display:block;
+	margin:2rem;
+	padding: 0.6rem 1.5rem;	
+	font-size: 0.8rem;
+	background-color: var(--container-bg-color);
+	color: var(--main-text-color);
+	border:1px solid var(--main-text-color);
+}
+#return:hover{
+	background-color: var(--hover-bg-color);
+	color:var(--container-bg-color);
+	border: 1px solid var(--container-bg-color);
+}

--- a/KnowledgeMap/src/main/resources/static/css/regist_form.css
+++ b/KnowledgeMap/src/main/resources/static/css/regist_form.css
@@ -1,0 +1,187 @@
+@charset "UTF-8";
+:root {
+	--main-bg-color: #f4f4fa;
+	--main-text-color: #201f30; 
+	--container-bg-color: #ffffff;
+	--line-color: #b0aec8; 
+	--hover-bg-color: #201f30;
+	--hover-text-color: white;
+	font-size: 16px;
+}
+
+h1{
+	font-size: 2rem;
+}
+/* form全体 */
+.registForm{
+	width: 80%;
+	max-width: 1100px;
+	min-width: 600px;
+	background-color: var(--container-bg-color);
+	border: 1px solid var(--line-color);
+	border-radius: 10px;
+	padding: 1%;
+}
+/* formの1行分 */
+.row{
+	display:grid;
+	grid-template-columns: 20% 1fr;
+	padding: 1% 0%;
+	align-items: start;
+}
+/* formの1行の右側 */
+.row label{
+	font-weight: bold;
+	font-size: 1rem;
+	color: var(--main-text-color);
+	text-align: right;
+}
+/* formの1行の左側 */
+.inputContainer{
+	padding:0px 5px;
+}
+/* error */
+.error {
+	margin-top: 4px;
+	color: red;
+	font-size: 0.9em;
+	min-height: 1.2em;
+}
+.error span:empty::after {
+	content: " ";
+	display: inline-block;
+	visibility: hidden;
+}
+#existingWordLink {
+	color: red;
+	cursor: pointer;
+	transition: color 0.2s;
+	text-decoration: none;
+}
+
+#existingWordLink:hover {
+	color: rgb(145, 32, 22);
+}
+.existingWordDetail{
+	display: none;
+	
+	margin-top: 10px;
+	padding: 16px;
+	border: 1px solid var(--line-color);
+	border-radius: 12px;
+	background-color: var(--main-bg-color);
+	width: 80%;
+	box-sizing: border-box;
+}
+.existingWordDetailVisible{
+	display:block;
+}
+/* category */
+#categoryInputContainer{
+	display:grid;
+	grid-template-columns: 1fr 1fr;
+	column-gap: 20px;
+	width: 80%;
+}
+#categoryId,
+#categoryName{
+	padding: 2px;
+	border: 1px solid var(--line-color);
+	border-radius: 4px;
+	font-size: 0.9rem;
+	width: 100%;
+}
+#categoryInputContainer label{
+	font-size: 0.8rem;
+	font-weight: normal;
+}
+/* category以外 */
+#wordName,
+#content,
+#relatedWordIds {
+	padding: 2px;
+	border: 1px solid var(--line-color);
+	border-radius: 4px;
+	font-size: 0.9rem;
+	width: 80%;
+}
+#content {
+	min-height: 200px;
+	resize: vertical;
+}
+/* 登録確認ボタン */
+#registConfirmBtn {
+	width: 300px;
+	background-color: var(--hover-bg-color);
+	color: var(--hover-text-color);
+	border: none;
+	padding: 10px 24px;
+	border-radius: 6px;
+	display: block;
+	margin:  0 auto;
+}
+
+#registConfirmBtn:hover {
+	background-color: #000;
+}
+
+/* 重複wordの表示 */
+.wordDetailContainer{
+	padding: 3%;
+	background-color: var(--container-bg-color);
+}
+.wordDetailContainer div{
+	margin:0%;
+}
+.wordNameContainer{
+	display: flex;
+	justify-content: space-between;
+}
+
+.wordName{
+	font-size: 2rem;
+}
+.content{
+	font-size: 1rem;
+	border-top: 2px solid var(--line-color);
+	border-bottom: 2px solid var(--line-color);
+	padding: 20px;
+}
+.category{
+	font-size: 0.7rem;
+}
+.relatedWords{
+	font-size: 0.7rem;
+}
+.relatedWords ul{
+	display:inline-block;
+	list-style: none;
+	padding-left: 0;
+}
+.relatedWords ul li{
+	display:inline-block;
+	padding-right: 20px;
+}
+.editBtn:hover{
+	padding: 10px;
+	text-align: center;
+	background-color:var(--hover-bg-color);
+	border:2px solid var(--hover-bg-color);
+	color: var(--hover-text-color);
+	border-radius: 10%;
+	cursor: pointer;
+	font-size: 1rem;
+}
+.editBtn{
+	padding: 10px;
+	text-align: center;
+	background-color:  var(--line-color);
+	border:2px solid var(--line-color);
+	color:var(--container-bg-color);
+	border-radius: 10%;
+	cursor: pointer;
+	font-size: 1rem;
+}
+
+
+

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -6,6 +6,7 @@
 	--line-color: #b0aec8;
 	--hover-bg-color: #201f30;
 	--hover-text-color: white;
+	font-size: 16px;
 }
 * {
 	box-sizing: border-box;
@@ -73,7 +74,7 @@ h4{
 	border: none;
 	border-radius: 0%;
 	cursor: pointer;
-	font-size: 16px;
+	font-size: 1rem;
 }
 #categoryList li,
 .wordList li{
@@ -94,7 +95,7 @@ h4{
 	border: none;
 	color:#777499;
 	border:2px solid var(--hover-bg-color);
-	font-size: 16px;
+	font-size: 1rem;
 	cursor: pointer;
 }
 .categoryDeleteBtn:hover,
@@ -113,7 +114,7 @@ h4{
 }
 
 .wordName{
-	font-size:32px;
+	font-size: 2rem;
 }
 .content{
 	font-size: 16px;
@@ -122,10 +123,10 @@ h4{
 	padding:5%;
 }
 .category{
-	font-size: 12px;
+	font-size: 0.8rem;
 }
 .relatedWords{
-	font-size: 14px;
+	font-size: 0.8rem;
 }
 .relatedWords ul{
 	display:inline-block;
@@ -145,7 +146,7 @@ h4{
 	color: var(--hover-text-color);
 	border-radius: 10%;
 	cursor: pointer;
-	font-size: 16px;
+	font-size: 1rem;
 }
 .editBtn{
 	padding: 10px;
@@ -155,13 +156,14 @@ h4{
 	color:var(--container-bg-color);
 	border-radius: 10%;
 	cursor: pointer;
-	font-size: 16px;
+	font-size: 1rem;
 }
 /* 新規登録 */
 
 #regist{
 	width:20%;
 	margin: 10px;
+	
 }
 #regist a{
 	text-decoration: none;

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -1,25 +1,5 @@
 @charset "utf-8";
-:root {
-	--main-bg-color: #f4f4fa;
-	--main-text-color: #201f30;
-	--container-bg-color:white;
-	--line-color: #b0aec8;
-	--hover-bg-color: #201f30;
-	--hover-text-color: white;
-	font-size: 16px;
-}
-* {
-	box-sizing: border-box;
-	margin: 0;
-	padding: 0;
-}
-body {
-	background-color: var(--main-bg-color);
-	color: var(--main-text-color);
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-}
+
 /* containers */
 .mainContainer {
 	display: flex;
@@ -36,7 +16,6 @@ h4{
 #wordListOuter,
 #wordDetailOuter{
 	background-color: var(--container-bg-color);
-	border: 1px solid var(#f4f4fa);
 	margin:1px;
 }
 #categoryOuter {
@@ -49,7 +28,7 @@ h4{
 	width: 50%;
 }
 .wordDetailContainer{
-	padding: 3%;
+	padding: 1.2rem;
 }
 /* categoryList, wordList */
 #categoryList, 
@@ -84,25 +63,24 @@ h4{
 .categoryBtn:hover,
 .wordBtnSelected,
 .categoryBtnSelected {
-	background-color: var(--hover-bg-color);
-	color:  var(--hover-text-color);
+	background-color: var(--main-text-color);
+	color:  var(--container-bg-color);
 	border:1px solid var(--hover-bg-color);
 }
 .categoryDeleteBtn,
 .wordDeleteBtn{
 	width: 20%;
 	background-color:  var(--container-bg-color);
-	border: none;
 	color:#777499;
-	border:2px solid var(--hover-bg-color);
+	border-radius: 0%;
+	border:2px solid var(--main-text-color);
 	font-size: 1rem;
 	cursor: pointer;
 }
 .categoryDeleteBtn:hover,
 .wordDeleteBtn:hover{
 	background-color: #e5e5ee;
-	color:var(--main-text-color);
-	border:2px solid var(--hover-bg-color);
+	color: var(--main-text-color);
 }
 /* wordDetail */
 .wordDetailContainer div{
@@ -138,47 +116,21 @@ h4{
 	display:inline-block;
 	padding-right:20px;
 }
-.editBtn:hover{
-	padding: 10px;
-	text-align: center;
-	background-color:var(--hover-bg-color);
-	border:2px solid var(--hover-bg-color);
-	color: var(--hover-text-color);
-	border-radius: 10%;
-	cursor: pointer;
-	font-size: 1rem;
-}
 .editBtn{
 	padding: 10px;
-	text-align: center;
-	background-color:  var(--line-color);
-	border:2px solid var(--line-color);
-	color:var(--container-bg-color);
-	border-radius: 10%;
-	cursor: pointer;
 	font-size: 1rem;
 }
-/* 新規登録 */
 
+/* 新規登録 */
 #regist{
 	width:20%;
 	margin: 10px;
-	
 }
 #regist a{
-	text-decoration: none;
-	background-color:var(--hover-bg-color);
-	color: var(--container-bg-color);
-	border:2px solid var(--hover-bg-color);
 	display: block;
 	padding:10px;
-	text-align: center;	
 }
-#regist a:hover{
-	background-color: var(--container-bg-color);
-	color: var(--hover-bg-color);
-	border: 2px solid var(--hover-bg-color);
-}
+
 
 
 

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -35,6 +35,8 @@ h4{
 #wordListOuter,
 #wordDetailOuter{
 	background-color: var(--container-bg-color);
+	border: 1px solid var(#f4f4fa);
+	margin:1px;
 }
 #categoryOuter {
 	width: 25%;
@@ -148,9 +150,9 @@ h4{
 .editBtn{
 	padding: 10px;
 	text-align: center;
-	background-color:  var(--container-bg-color);
-	border:2px solid var(--hover-bg-color);
-	color:var(--hover-bg-color);
+	background-color:  var(--line-color);
+	border:2px solid var(--line-color);
+	color:var(--container-bg-color);
 	border-radius: 10%;
 	cursor: pointer;
 	font-size: 16px;
@@ -165,10 +167,15 @@ h4{
 	text-decoration: none;
 	background-color:var(--hover-bg-color);
 	color: var(--container-bg-color);
+	border:2px solid var(--hover-bg-color);
 	display: block;
 	padding:10px;
-	text-align: center;
-	
+	text-align: center;	
+}
+#regist a:hover{
+	background-color: var(--container-bg-color);
+	color: var(--hover-bg-color);
+	border: 2px solid var(--hover-bg-color);
 }
 
 

--- a/KnowledgeMap/src/main/resources/static/js/regist_form.js
+++ b/KnowledgeMap/src/main/resources/static/js/regist_form.js
@@ -1,0 +1,13 @@
+const link = document.getElementById("existingWordLink");
+const existingWordDetail = document.querySelector(".existingWordDetail");
+const switcher = document.querySelector(".switcher");
+
+link.addEventListener("click", async () => {
+	console.log(switcher.textContent)
+	existingWordDetail.classList.toggle("existingWordDetailVisible");
+	if (!switcher.classList.toggle("bi-caret-down-fill")) {
+		switcher.classList.add("bi-caret-up-fill");
+	} else {
+		switcher.classList.remove("bi-caret-up-fill");
+	}
+})

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -135,7 +135,7 @@ async function showWordDetail(wordId) {
 			const editBtn = document.createElement("button");
 			editBtn.classList.add("editBtn");
 			const span = document.createElement("span");
-			span.classList.add("bi-pencil-square");
+			span.classList.add("bi-pencil-fill");
 			editBtn.append(span);
 			editBtn.addEventListener("click", () => {
 				location.href = `/words/${wordId}/editForm`;

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -4,92 +4,117 @@
 <head>
 	<meta charset="UTF-8">
 	<title>単語の登録</title>
-	<script th:src="@{/js/form.js}" defer></script>
+	<link rel="stylesheet" th:href="@{/css/common.css}">
+	<link rel="stylesheet" th:href="@{/css/regist_form.css}">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+
+	<script th:src="@{/js/regist_form.js}" defer></script>
 </head>
 
 <body>
 	<h1>新規登録</h1>
-	<form th:action="@{/registConfirm}" method="post">
-		<table th:object="${wordForm}" border="1">
+	<form class="registForm" th:action="@{/registConfirm}" method="post" th:object="${wordForm}">
 		<input type="hidden" th:field="*{id}">
-			<tr>
-				<th>word</th>
-				<td>
-					<input type="text" th:field="*{wordName}">
-					<span th:errors="*{wordName}"></span>
-				</td>
-			</tr>
-			<tr>
-				<th>content</th>
-				<td>
-					<textarea th:field="*{content}"></textarea>
-					<span th:errors="*{content}"></span>
-				</td>
-			</tr>
-			<tr>
-				<th>category</th>
-				<td>
-					<select th:field="*{categoryId}">
-						<option value="">カテゴリを選択</option>
-						<option th:each="category : ${categories}" 
-								th:value="${category.id}" 
+
+		<div class="row">
+			<label for="wordName">単語</label>
+			<div class="inputContainer">
+				<input type="text" th:field="*{wordName}" autofocus>
+				<div class="error">
+					<div th:if="${#fields.hasErrors('wordName')}">
+						<div>
+							<span class="bi bi-exclamation-circle-fill"></span>
+							<a href="#" id="existingWordLink">
+								<span th:text="${existingWord.wordName}"></span>
+								<span class="bi bi-caret-down-fill switcher"></span>
+							</a>
+							<span th:errors="*{wordName}"></span>
+						</div>
+
+					</div>
+					<!-- 既存wordの詳細（ここに埋め込む） -->
+					<div th:if="${existingWord != null}" class="existingWordDetail" th:object="${existingWord}">
+						<div class="wordNameContainer">
+							<div class="wordName" th:text="*{wordName}"></div>
+							<a th:href="@{/words/{id}/editForm(id=${existingWord.id},fromRegist='fromRegist')}"
+								class="editBtn">
+								<span class="bi bi-pencil-square"></span>
+							</a>
+						</div>
+						<div class="category">
+							<span>カテゴリ：</span><span th:text="*{category.name}"></span>
+						</div>
+						<div class="content" th:text="*{content}"></div>
+						<div class="relatedWords">
+							<span>参照：</span>
+							<ul>
+								<li th:each="relatedWord : *{relatedWords}" th:text="${relatedWord.wordName}"></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+
+		<div class="row">
+			<label for="categoryId">カテゴリ</label>
+			<div class="inputContainer">
+				<div id="categoryInputContainer">
+					<div>
+						<div><label for="categoryId">カテゴリ一覧から選ぶ</label></div>
+						<select th:field="*{categoryId}">
+							<option value="">カテゴリを選択</option>
+							<option th:each="category : ${categories}" th:value="${category.id}"
 								th:text="${category.name}">
-						</option>
-					</select>
-					<span>または新しいカテゴリーをつくる
+							</option>
+						</select>
+					</div>
+					<div>
+						<div><label for="categoryName">または新規作成<span class="bi bi-plus-circle-fill"></span></label>
+						</div>
 						<input type="text" th:field="*{categoryName}">
-					</span>
+					</div>
+				</div>
+				<div class="error">
+					<span th:if="${#fields.hasErrors('categoryNotNull')}" class="bi bi-exclamation-circle-fill"></span>
 					<span th:errors="*{categoryNotNull}"></span>
-				</td>
-			</tr>
-			<tr>
-				<th>relatedWords</th>
-				<td>
-					<select multiple th:field="*{relatedWordIds}">
-						<option th:each="word : ${wordList}" 
-								th:value="${word.id}" 
-								th:text="${word.wordName}">
-						</option>
-					</select>
+				</div>
+			</div>
+		</div>
+
+		<div class="row">
+			<label for="content">内容</label>
+			<div class="inputContainer">
+				<textarea th:field="*{content}"></textarea>
+				<div class="error">
+					<span th:if="${#fields.hasErrors('content')}" class="bi bi-exclamation-circle-fill"></span>
+					<span th:errors="*{content}"></span>
+				</div>
+			</div>
+		</div>
+
+		<div class="row">
+			<label for="relatedWordIds">参照</label>
+			<div class="inputContainer">
+				<select multiple th:field="*{relatedWordIds}">
+					<option value="">カテゴリを選択</option>
+					<option th:each="word : ${wordList}" th:value="${word.id}" th:text="${word.wordName}">
+					</option>
+				</select>
+				<div class="error">
+					<span th:if="${#fields.hasErrors('relatedWordIds')}" class="bi bi-exclamation-circle-fill"></span>
 					<span th:errors="*{relatedWordIds}"></span>
-				</td>
-			</tr>
-		</table>
-		<button>入力内容の確認</button>
+				</div>
+			</div>
+		</div>
+
+		<button id="registConfirmBtn">入力内容の確認</button>
+
 	</form>
+
 	<a th:href="@{/wordList}">一覧へ戻る</a>
 
-	<div th:if="${existingWord} != null">
-		<h3>【登録済みの内容】</h3>
-		<table th:object="${existingWord}" border="1">
-			<tr>
-				<th>word</th>
-				<td th:text="*{wordName}"></td>
-			</tr>
-			<tr>
-				<th>content</th>
-				<td th:text="*{content}"></td>
-			</tr>
-			<tr>
-				<th>category</th>
-				<td th:text="*{category.name}"></td>
-			</tr>
-			<tr>
-				<th>related_words</th>
-				<td>
-					<ul>
-						<li th:each="relatedWord : *{relatedWords}" 
-							th:text="${relatedWord.wordName}">
-						</li>
-					</ul>
-				</td>
-			</tr>
-		</table>
-		<form th:action="@{/words/{id}/editForm(id=${existingWord.id})}">
-			<input type="hidden" name="fromRegist" value="fromRegist">
-			<button type="submit">既存の登録内容を編集する</button>
-		</form>
-	</div>
 </body>
 
 </html>

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -4,6 +4,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>単語の登録</title>
+	
 	<link rel="stylesheet" th:href="@{/css/common.css}">
 	<link rel="stylesheet" th:href="@{/css/regist_form.css}">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
@@ -24,7 +25,7 @@
 					<div th:if="${#fields.hasErrors('wordName')}">
 						<div>
 							<span class="bi bi-exclamation-circle-fill"></span>
-							<a href="#" id="existingWordLink">
+							<a th:if="${existingWord} != null" href="#" id="existingWordLink">
 								<span th:text="${existingWord.wordName}"></span>
 								<span class="bi bi-caret-down-fill switcher"></span>
 							</a>
@@ -32,13 +33,13 @@
 						</div>
 
 					</div>
-					<!-- 既存wordの詳細（ここに埋め込む） -->
+					<!-- 既存wordの詳細（クリックイベントで表示させる） -->
 					<div th:if="${existingWord != null}" class="existingWordDetail" th:object="${existingWord}">
 						<div class="wordNameContainer">
 							<div class="wordName" th:text="*{wordName}"></div>
-							<a th:href="@{/words/{id}/editForm(id=${existingWord.id},fromRegist='fromRegist')}"
-								class="editBtn">
-								<span class="bi bi-pencil-square"></span>
+							<a  th:href="@{/words/{id}/editForm(id=${existingWord.id},fromRegist='fromRegist')}"
+								class="button editBtn">
+								<span class="bi bi-pencil-fill"></span>
 							</a>
 						</div>
 						<div class="category">
@@ -55,7 +56,6 @@
 				</div>
 			</div>
 		</div>
-
 
 		<div class="row">
 			<label for="categoryId">カテゴリ</label>
@@ -95,10 +95,10 @@
 		</div>
 
 		<div class="row">
-			<label for="relatedWordIds">参照</label>
+			<label for="relatedWordIds">関連語</label>
 			<div class="inputContainer">
 				<select multiple th:field="*{relatedWordIds}">
-					<option value="">カテゴリを選択</option>
+					<option value="">関連語を選択</option>
 					<option th:each="word : ${wordList}" th:value="${word.id}" th:text="${word.wordName}">
 					</option>
 				</select>
@@ -113,7 +113,7 @@
 
 	</form>
 
-	<a th:href="@{/wordList}">一覧へ戻る</a>
+	<a id="return" class="button" th:href="@{/wordList}">一覧へ戻る</a>
 
 </body>
 

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -14,7 +14,7 @@
 	<h1>単語帳</h1>
 
 	<div id="regist">
-		<a th:href="@{/showWordForm}"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
+		<a th:href="@{/showWordForm}" class="button"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
 	</div>
 
 	<div th:if="${regist_ok} != null" th:text="${regist_ok}"></div>

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -5,6 +5,7 @@
 	<meta charset="UTF-8">
 	<title>単語一覧</title>
 	<link rel="stylesheet" th:href="@{/css/word_list.css}">
+	<link rel="stylesheet" th:href="@{/css/common.css}">
 	<script th:src="@{/js/word_list.js}" defer></script>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 </head>
@@ -24,7 +25,7 @@
 	<div class="mainContainer">
 		<!-- categoryList -->
 		<div id="categoryOuter">
-			<h4>カテゴリ</h4>
+			<h4>Category</h4>
 			<div class="categoryContainer">
 				<ul id="categoryList">
 					<li th:each="category : ${categories}" th:object="${category}">
@@ -36,14 +37,14 @@
 
 		<!-- wordList -->
 		<div id="wordListOuter">
-			<h4>単語</h4>
+			<h4>Word</h4>
 			<div class="wordListContainer">
 			</div>
 		</div>
 
 		<!-- wordDetail -->
 		<div id="wordDetailOuter">
-			<h4>内容</h4>
+			<h4>Detail</h4>
 			<div class="wordDetailContainer">
 			</div>
 		</div>


### PR DESCRIPTION
###  regist_form.cssを実装しました。

- 登録済みwordNameで登録しようとするとバリデーションエラーが発生し既存のword情報を表示させる仕様について、
この表示をJavaScriptのクリックイベントでトグル表示できるように変更しました。

-  この既存word情報の表示位置をwordNameのinputの真下に配置するため、
form内のbuttonタグ から aタグに変更しました。(buttonではformのネストが発生してしまうため)

- common.cssを作成し、各ページ共通の 背景色・文字色・ボタンの変化色 などをCSS変数として定義しました。