### PR TITLE
Feature/#67 edit css

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -112,7 +112,7 @@ public class WordController {
 		Word registedWord = wordService.addWord(wordForm);
 		System.out.println("■ ■ ■ ■ ■ ■ ■ " +registedWord.getWordName());
 		System.out.println("■ ■ ■ ■ ■ ■ ■ " +registedWord.getCategory().getId());
-		redirectAttribute.addFlashAttribute("regist_ok", "登録完了しました");
+		redirectAttribute.addFlashAttribute("regist_ok", "登録しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
 		return String.format("redirect:/wordList?categoryId=%d&id=%d", registedWord.getCategory().getId(),
 				registedWord.getId());

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -126,7 +126,7 @@ public class WordDetailController {
 			@PathVariable("id") Integer id,
 			RedirectAttributes redirectAttribute) {
 		Word updatedWord = wordService.updateWord(id, wordForm);
-		redirectAttribute.addFlashAttribute("edit_ok", "編集が完了しました");
+		redirectAttribute.addFlashAttribute("edit_ok", "編集しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
 		return String.format("redirect:/wordList?categoryId=%d&id=%d", updatedWord.getCategory().getId(),updatedWord.getId());
 	}

--- a/KnowledgeMap/src/main/resources/static/css/common.css
+++ b/KnowledgeMap/src/main/resources/static/css/common.css
@@ -9,7 +9,6 @@ h1{
 	--container-bg-color: white;
 	--hover-bg-color: #353e60;
 	--line-color: #b0aec8;
-
 }
 
 * {

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -32,6 +32,9 @@ h4{
 .wordDetailContainer{
 	padding: 1.2rem;
 }
+.wordDetailContainer .message{
+	color: red;
+}
 /* categoryList, wordList */
 #categoryList, 
 .wordList{

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -1,8 +1,5 @@
 @charset "utf-8";
-:root{
-	--modal-top:50%;
-	--modal-right:50%;
-}
+
 /* containers */
 .mainContainer {
 	display: flex;
@@ -139,18 +136,24 @@ h4{
 	display: block;
 	padding:10px;
 }
-/* 削除確認モーダル */
-
+/* 削除確認モーダル
+   表示位置はクリックしたボタン要素の下になるよう変数で定義
+ */
 .modalHidden{
 	display:none;
-
+}
+:root{
+	--modal-top:50%;
+	--modal-left:50%;
 }
 #deleteConfirmModal{
 	position: absolute;
 	top: var(--modal-top);
-	right: var(--modal-right);
+	left: var(--modal-left);
+	
 	padding:1.5rem;
 	text-align: center;	
+	
 	background-color: #f5dede;
 	color: var(--main-text-color);
 	border: 2px solid var(--main-text-color);

--- a/KnowledgeMap/src/main/resources/static/css/word_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/word_list.css
@@ -1,5 +1,8 @@
 @charset "utf-8";
-
+:root{
+	--modal-top:50%;
+	--modal-right:50%;
+}
 /* containers */
 .mainContainer {
 	display: flex;
@@ -8,7 +11,7 @@
 	max-width: 1100px;
 	min-width: 500px;
 
-	margin:2%;
+	margin:1rem 2rem 10rem;
 }
 h4{
 	text-align: center;
@@ -63,6 +66,7 @@ h4{
 #categoryList li,
 .wordList li{
 	display: flex;
+	border: none;
 }
 .wordBtn:hover,
 .categoryBtn:hover,
@@ -70,7 +74,7 @@ h4{
 .categoryBtnSelected {
 	background-color: var(--main-text-color);
 	color:  var(--container-bg-color);
-	border:1px solid var(--hover-bg-color);
+	border:1px solid var(--main-text-color);
 }
 .categoryDeleteBtn,
 .wordDeleteBtn{
@@ -135,46 +139,24 @@ h4{
 	display: block;
 	padding:10px;
 }
+/* 削除確認モーダル */
 
+.modalHidden{
+	display:none;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+}
+#deleteConfirmModal{
+	position: absolute;
+	top: var(--modal-top);
+	right: var(--modal-right);
+	padding:1.5rem;
+	text-align: center;	
+	background-color: #f5dede;
+	color: var(--main-text-color);
+	border: 2px solid var(--main-text-color);
+	border-radius: 10px;
+}
+#deleteConfirmModal button{
+	margin: 0.5rem 1rem;
+	padding:0.5rem;
+}

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -199,7 +199,8 @@ async function deleteWord(event, wordId, li) {
 		const res = await fetch(`/api/words/${wordId}`, { method: "DELETE" });
 		if (res.ok) {
 			li.remove();
-			clearWordDetail()
+			clearWordDetail();
+			document.querySelector(".deleteMsg").textContent = "削除しました";
 		} else {
 			alert("削除に失敗しました");
 		}

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -1,4 +1,23 @@
-//新規登録や編集を実行後、対象wordのカテゴリとwordNameが選択された状態にする(色がつく)
+
+// 各コンテナ
+const mainConteiner = document.querySelector(".mainContainer");
+const categoryContainer = document.querySelector(".categoryContainer");
+const wordListContainer = document.querySelector(".wordListContainer");
+const wordDetailContainer = document.querySelector(".wordDetailContainer");
+// カテゴリ
+let currentCategoryId = null;
+const categoryList = document.querySelector(".categoryList");
+const categoryBtns = document.querySelectorAll(".categoryBtn");
+//削除確認モーダル
+const deleteConfirmModal = document.getElementById("deleteConfirmModal");
+const deleteOkBtn = document.getElementById("deleteOk");
+const deleteNgBtn = document.getElementById("deleteNg");
+
+/*
+	新規登録または編集を実行後にword_listに戻ると
+	処理を実行した単語が表示された状態にする
+	(カテゴリ一覧と単語一覧から該当する対象が選択され、かつwordDetailが表示された状態)
+*/
 window.addEventListener("DOMContentLoaded", async () => {
 	const params = new URLSearchParams(window.location.search);
 	const categoryId = params.get("categoryId");
@@ -12,27 +31,24 @@ window.addEventListener("DOMContentLoaded", async () => {
 		await showWordDetail(wordId);
 	}
 })
-// 各コンテナ
-const mainConteiner = document.querySelector(".mainContainer");
-const categoryContainer = document.querySelector(".categoryContainer");
-const wordListContainer = document.querySelector(".wordListContainer");
-const wordDetailContainer = document.querySelector(".wordDetailContainer");
-// カテゴリ
-let currentCategoryId = null;
-const categoryList = document.querySelector(".categoryList");
-const categoryBtns = document.querySelectorAll(".categoryBtn");
-
+/*
+	カテゴリをクリックすると
+	そのカテゴリに属する単語一覧を表示する
+*/
 categoryBtns.forEach(categoryBtn => {
 	categoryBtn.addEventListener("click", async () => {
 		//選択中カテゴリの設定
 		clearCategorySelection();
 		currentCategoryId = categoryBtn.getAttribute("data-id");
 		categoryBtn.classList.add("categoryBtnSelected");
-		//単語一覧を表示
+
 		wordListContainer.innerHTML = "";
+		closeModal();
+
 		showWordList(currentCategoryId);
 	})
 })
+
 // カテゴリ選択をクリア
 function clearCategorySelection() {
 	document.querySelectorAll(".categoryDeleteBtn").forEach(btn => btn.remove());
@@ -42,14 +58,13 @@ function clearCategorySelection() {
 function setCategorySelection(categoryId) {
 	[...categoryBtns].find(btn => btn.getAttribute("data-id") === categoryId).classList.add("categoryBtnSelected");
 }
-// 選択中wordの色変更
+// 選択中の単語の色変更
 function setWordSelection(wordId) {
 	const wordBtns = document.querySelectorAll(".wordBtn");
 	[...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") === wordId)
 		.classList.add("wordBtnSelected");
 }
-
-// wordList表示
+// 単語一覧を表示
 async function showWordList(categoryId) {
 	try {
 		const res = await fetch(`/api/words?categoryId=${categoryId}`);
@@ -91,12 +106,12 @@ async function showWordList(categoryId) {
 					wordDeleteBtn.appendChild(span);
 
 					wordDeleteBtn.addEventListener("click", (event) => {
-						wordDetailContainer.innerHTML = "";
-						deleteWord(event, word.id, li)
+						deleteWord(event, word.id, li);
 					});
 
 					wordBtn.addEventListener("click", () => {
 						wordDetailContainer.innerHTML = "";
+						closeModal();
 						document.querySelectorAll(".wordBtnSelected").forEach(btn => btn.classList.remove("wordBtnSelected"))
 						document.querySelectorAll(".wordDeleteBtn").forEach(btn => btn.remove());
 						wordBtn.classList.add("wordBtnSelected");
@@ -130,7 +145,7 @@ async function showWordDetail(wordId) {
 			const wordName = document.createElement("div");
 			wordName.classList.add("wordName");
 			wordName.textContent = wordDetail.wordName;
-			
+
 			//編集ボタン
 			const editBtn = document.createElement("button");
 			editBtn.classList.add("editBtn");
@@ -140,7 +155,7 @@ async function showWordDetail(wordId) {
 			editBtn.addEventListener("click", () => {
 				location.href = `/words/${wordId}/editForm`;
 			})
-			wordNameContainer.append(wordName,editBtn);
+			wordNameContainer.append(wordName, editBtn);
 			//カテゴリ
 			const categoryContainer = document.createElement("div");
 			categoryContainer.classList.add("category");
@@ -155,8 +170,8 @@ async function showWordDetail(wordId) {
 			const content = document.createElement("div");
 			content.classList.add("content");
 			content.textContent = wordDetail.content;
-			
-			wordDetailContainer.append(wordNameContainer,categoryContainer,content);
+
+			wordDetailContainer.append(wordNameContainer, categoryContainer, content);
 			//関連語
 			if (wordDetail.relatedWords && wordDetail.relatedWords.length > 0) {
 				const relatedWordsContainer = document.createElement("div");
@@ -180,65 +195,69 @@ async function showWordDetail(wordId) {
 //category削除
 async function deleteCategory(event, categoryId) {
 	event.stopPropagation();
-	try {
-		const res = await fetch(`/api/categories/${categoryId}`, { method: "DELETE" });
-		if (res.ok) {
-			location.reload();
-		} else {
-			alert("削除に失敗しました");
+	showModal(event,async () => {
+		try {
+			const res = await fetch(`/api/categories/${categoryId}`, { method: "DELETE" });
+			if (res.ok) {
+				location.reload();
+			} else {
+				alert("削除に失敗しました");
+			}
+		} catch (error) {
+			console.error(error);
+			alert("通信エラーが発生しました");
 		}
-	} catch (error) {
-		console.error(error);
-		alert("通信エラーが発生しました");
-	}
+	})
 }
 //word削除
 async function deleteWord(event, wordId, li) {
 	event.stopPropagation();
-	try {
-		const res = await fetch(`/api/words/${wordId}`, { method: "DELETE" });
-		if (res.ok) {
-			li.remove();
-			clearWordDetail();
-			document.querySelector(".deleteMsg").textContent = "削除しました";
-		} else {
-			alert("削除に失敗しました");
+	showModal(event,async (isConfirmed) => {
+		if (!isConfirmed) {
+			return;
 		}
-	} catch (error) {
-		console.log(error);
-	}
+		try {
+			const res = await fetch(`/api/words/${wordId}`, { method: "DELETE" });
+			if (res.ok) {
+				li.remove();
+				wordDetailContainer.innerHTML = "";
+				clearWordDetail();
+				document.querySelector(".deleteMsg").textContent = "削除しました";
+			} else {
+				alert("削除に失敗しました");
+			}
+		} catch (error) {
+			console.log(error);
+		}
+	})
 }
 
+// 削除確認モーダルを表示させる
+// 押したボタンによって 削除実行する or 実行しない を切り替える
+function showModal(event,func) {
+	// モーダルの表示位置
+	const rect = event.currentTarget.getBoundingClientRect();
+	console.log(rect);
+	const modalTop = rect.bottom + scrollY + 8; 
+	const modalRight = window.innerWidth - ( rect.x + rect.width ) + scrollX;
+	document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
+	document.documentElement.style.setProperty('--modal-right', `${modalRight}px`);
 
+	deleteConfirmModal.classList.remove("modalHidden");
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+	deleteOk.onclick = () => {
+		func(true);
+		closeModal();
+	};
+	deleteNg.onclick = () => {
+		func(false);
+		closeModal();
+	};
+}
+// 削除確認モーダルを閉じる
+function closeModal() {
+	if (!deleteConfirmModal.classList.contains("modalHidden")) {
+		deleteConfirmModal.classList.add("modalHidden");
+	}
+}
 

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -233,22 +233,25 @@ async function deleteWord(event, wordId, li) {
 }
 
 // 削除確認モーダルを表示させる
-// 押したボタンによって 削除実行する or 実行しない を切り替える
+// 「引数として真偽値を受け取り 削除実行のリクエストを送る or 何もしない」という関数オブジェクトを 引数として受け取る
 function showModal(event,func) {
-	// モーダルの表示位置
-	const rect = event.currentTarget.getBoundingClientRect();
-	console.log(rect);
-	const modalTop = rect.bottom + scrollY + 8; 
-	const modalRight = window.innerWidth - ( rect.x + rect.width ) + scrollX;
-	document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
-	document.documentElement.style.setProperty('--modal-right', `${modalRight}px`);
-
+	// モーダルの表示
 	deleteConfirmModal.classList.remove("modalHidden");
-
+	// モーダルの表示位置を設定
+	const rect = event.currentTarget.getBoundingClientRect();
+	
+	const modalTop = rect.bottom + scrollY + 8; 
+	const modalLeft = rect.right - deleteConfirmModal.offsetWidth;
+	
+	document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
+	document.documentElement.style.setProperty('--modal-left', `${modalLeft}px`);
+	
+	// OKボタンクリック -> func(true)を実行してモーダルを閉じる
 	deleteOk.onclick = () => {
 		func(true);
 		closeModal();
 	};
+	// NGボタンクリック -> func(false)を実行してモーダルを閉じる
 	deleteNg.onclick = () => {
 		func(false);
 		closeModal();

--- a/KnowledgeMap/src/main/resources/templates/edit_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_confirm.html
@@ -1,57 +1,62 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
 <head>
 	<meta charset="UTF-8">
 	<title>edit_confirm</title>
+
+	<link rel="stylesheet" th:href="@{/css/common.css}">
+	<link rel="stylesheet" th:href="@{/css/regist_confirm.css}">
+	
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+
 </head>
+
 <body>
 	<h1>edit_confirm</h1>
 	<h2>以下の内容で編集します</h2>
-	<form th:action="@{/words/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
-	<input type="hidden" th:field="*{id}" />
-		<table>
-			<tr>
-				<th>word</th>
-				<td>
-					<span th:text="*{wordName}"></span>
-					<input type="hidden" th:field="*{wordName}">
-				</td>
-			</tr>
-			<tr>
-				<th>content</th>
-				<td>
-					<span th:text="*{content}"></span>
-					<input type="hidden" th:field="*{content}">
-				</td>
-			</tr>
-			<tr>
-				<th>category</th>
-				<td>
-					<span th:text="*{categoryName}"></span>
-					<input type="hidden" th:field="*{categoryId}">
-				</td>
-			</tr>
-			<tr>
-				<th>related_words</th>
-				<td>
-					<ul>
-						<li th:each="relatedWordName : ${relatedWordNames}" th:text="${relatedWordName}"></li>
-					</ul>
-					<input type="hidden" th:field="*{relatedWordIds}">
-				</td>
-			</tr>
-		</table>
+	<form class="commonForm" th:action="@{/words/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
+
+		<input type="hidden" th:field="*{id}" />
+		<input type="hidden" th:field="*{wordName}">
+		<input type="hidden" th:field="*{categoryId}">
+		<input type="hidden" th:field="*{content}">
+		<input type="hidden" th:field="*{relatedWordIds}">
+
+		<div class="row">
+			<label for="wordName">単語</label>
+			<div class="inputContainer" id="wordName" th:text="*{wordName}"></div>
+		</div>
+
+		<div class="row">
+			<label for="category">カテゴリ</label>
+			<div class="inputContainer" id="category" th:text="*{categoryName}"></div>
+		</div>
+
+		<div class="row">
+			<label for="content">内容</label>
+			<div class="inputContainer" id="content" th:text="*{content}"></div>
+		</div>
+
+		<div class="row">
+			<label for="relatedWords">関連語</label>
+			<div class="inputContainer" id="relatedWords">
+				<ul>
+					<li th:each="relatedWordName : ${relatedWordNames}" th:text="${relatedWordName}"></li>
+				</ul>
+			</div>
+		</div>
+
 		<button type="submit">編集する</button>
 	</form>
-	<form th:action="@{/words/{id}/editForm(id=${word.id})}" th:object="${wordForm}"
-		style="display:inline;">
+	<form th:action="@{/words/{id}/editForm(id=${word.id})}" th:object="${wordForm}" style="display:inline;">
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">
 		<input type="hidden" th:field="*{relatedWordIds}">
 		<input type="hidden" th:field="*{categoryName}">
 		<input th:if="${fromRegist}" type="hidden" name="fromRegist" value="${fromRegist}">
-		<button type="submit">入力画面に戻る</button>
+		<button  id="return"  type="submit">入力画面に戻る</button>
 	</form>
 </body>
 

--- a/KnowledgeMap/src/main/resources/templates/edit_form.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_form.html
@@ -3,65 +3,111 @@
 
 <head>
 	<meta charset="UTF-8">
-	<title>word編集</title>
+	<title>編集</title>
+
+	<link rel="stylesheet" th:href="@{/css/common.css}">
+	<link rel="stylesheet" th:href="@{/css/regist_form.css}">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+
 	<script th:src="@{/js/form.js}" defer></script>
 
 </head>
 
 <body>
-	<h1>word編集</h1>
+	<h1>編集</h1>
 	<p th:if="${word_duplicate} != null" th:text="${word_duplicate}"></p>
-	<form th:action="@{/words/{id}/editConfirm(id=${word.id})}" method="post">
-		<table th:object="${wordForm}">
-			<input type="hidden" th:field="*{id}" />
-			<tr>
-				<th>word</th>
-				<td>
-					<input type="text" th:field="*{wordName}">
-					<span th:errors="*{wordName}"></span>
-				</td>
-			</tr>
-			<tr>
-				<th>content</th>
-				<td>
+	<form class="commonForm" th:action="@{/words/{id}/editConfirm(id=${word.id})}" method="post" th:object="${wordForm}">
+		<input type="hidden" th:field="*{id}" />
+		<div class="row">
+			<label for="wordName">単語</label>
+			<div class="inputContainer">
+				<input type="text" th:field="*{wordName}" autofocus>
+				<div class="error">
+					<div th:if="${#fields.hasErrors('wordName')}">
+						<div>
+							<span class="bi bi-exclamation-circle-fill"></span>
+							<a th:if="${existingWord} != null" href="#" id="existingWordLink">
+								<span th:text="${existingWord.wordName}"></span>
+								<span class="bi bi-caret-down-fill switcher"></span>
+							</a>
+							<span th:errors="*{wordName}"></span>
+						</div>
+					</div>
+				</div>
+				<!-- 既存wordの詳細（クリックイベントで表示させる） -->
+				<div th:if="${existingWord != null}" class="existingWordDetail" th:object="${existingWord}">
+					<div class="wordNameContainer">
+						<div class="wordName" th:text="*{wordName}"></div>
+						<a th:href="@{/words/{id}/editForm(id=${existingWord.id},fromRegist='fromRegist')}"
+							class="button editBtn">
+							<span class="bi bi-pencil-fill"></span>
+						</a>
+					</div>
+					<div class="category">
+						<span>カテゴリ：</span><span th:text="*{category.name}"></span>
+					</div>
+					<div class="content" th:text="*{content}"></div>
+					<div class="relatedWords">
+						<span>参照：</span>
+						<ul>
+							<li th:each="relatedWord : *{relatedWords}" th:text="${relatedWord.wordName}"></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="row">
+				<label for="categoryId">カテゴリ</label>
+				<div class="inputContainer">
+					<div id="categoryInputContainer">
+						<div>
+							<div><label for="categoryId">カテゴリ一覧から選ぶ</label></div>
+							<select th:field="*{categoryId}">
+								<option value="">カテゴリを選択</option>
+								<option th:each="category : ${categories}" th:value="${category.id}"
+									th:text="${category.name}">
+								</option>
+							</select>
+						</div>
+						<div>
+							<div><label for="categoryName">または新規作成<span class="bi bi-plus-circle-fill"></span></label>
+							</div>
+							<input type="text" th:field="*{categoryName}">
+						</div>
+					</div>
+					<div class="error">
+						<span th:if="${#fields.hasErrors('categoryNotNull')}" class="bi bi-exclamation-circle-fill"></span>
+						<span th:errors="*{categoryNotNull}"></span>
+					</div>
+				</div>
+			</div>
+
+			<div class="row">
+				<label for="content">内容</label>
+				<div class="inputContainer">
 					<textarea th:field="*{content}"></textarea>
-					<span th:errors="*{content}"></span>
-				</td>
-			</tr>
-			<tr>
-				<th>category</th>
-				<td>
-					<select th:field="*{categoryId}" required>
-						<option value="">カテゴリを選択</option>
-						<option th:each="category : ${categories}" 
-								th:value="${category.id}" 
-								th:text="${category.name}">
+					<div class="error">
+						<span th:if="${#fields.hasErrors('content')}" class="bi bi-exclamation-circle-fill"></span>
+						<span th:errors="*{content}"></span>
+					</div>
+				</div>
+			</div>
+
+			<div class="row">
+				<label for="relatedWordIds">関連語</label>
+				<div class="inputContainer">
+					<select multiple th:field="*{relatedWordIds}">
+						<option value="">関連語を選択</option>
+						<option th:each="word : ${wordList}" th:value="${word.id}" th:text="${word.wordName}">
 						</option>
 					</select>
-					<span th:errors="*{categoryId}"></span>
-					<span>または新しいカテゴリーをつくる
-						<input type="text" th:field="*{categoryName}">
-					</span>
-					<span th:errors="*{categoryNotNull}"></span>
-				</td>
-			</tr>
-			<tr>
-				<th>related_words</th>
-				<td>
-					<ul>
-						<li th:each="relatedWordName : ${relatedWordNames}" th:text="${relatedWordName}"></li>
-					</ul>
-					<select multiple th:field="*{relatedWordIds}">
-					    <option th:each="relatedWord : ${wordList}" 
-								th:if="${relatedWord.id} != ${word.id}"
-					            th:value="${relatedWord.id}" 
-					            th:text="${relatedWord.wordName}">
-					    </option>
-					</select>
-				</td>
-			</tr>
-		</table>
-		<input th:if="${fromRegist}" type="hidden" name="fromRegist" value="${fromRegist}">
+					<div class="error">
+						<span th:if="${#fields.hasErrors('relatedWordIds')}" class="bi bi-exclamation-circle-fill"></span>
+						<span th:errors="*{relatedWordIds}"></span>
+					</div>
+				</div>
+			</div>
+
 		<button type="submit">入力内容の確認</button>
 	</form>
 	<!-- 新規登録からの遷移の場合、戻るボタンは 登録画面へ -->
@@ -70,13 +116,14 @@
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">
 		<input type="hidden" th:field="*{relatedWordIds}">
-		<button>登録確認に戻る</button>
+		<button id="return">登録確認に戻る</button>
 	</form>
 	<!-- 編集からの遷移の場合、戻るボタンはword一覧へ-->
 	<form th:unless="${fromRegist}" th:action="@{/wordList}">
 		<input type="hidden" th:field="${wordForm.categoryId}">
 		<input type="hidden" th:field="${word.id}">
-		<button>word一覧へ</button>		
+		<button id="return">単語一覧へ戻る </button>
 	</form>
 </body>
+
 </html>

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -17,11 +17,6 @@
 		<a th:href="@{/showWordForm}" class="button"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
 	</div>
 
-	<div th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
-	<div th:if="${delete_ok} != null" th:text="${delete_ok}"></div>
-	<div th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
-	<div th:if="${regist_cancel} != null" th:text="${regist_cancel}"></div>
-
 	<div class="mainContainer">
 		<!-- categoryList -->
 		<div id="categoryOuter">
@@ -46,6 +41,8 @@
 		<div id="wordDetailOuter">
 			<h4>Detail</h4>
 			<div class="wordDetailContainer">
+				<div class="message" th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
+				<div class="message" th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
 			</div>
 		</div>
 </body>

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -45,6 +45,12 @@
 				<div class="message" th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
 			</div>
 		</div>
+		<!-- 削除確認モーダル -->
+		<div id="deleteConfirmModal" class="modalHidden">
+			<p>本当に削除しますか？</p>
+			<button id="deleteOk">はい</button>
+			<button id="deleteNg">いいえ</button>
+		</div>
 </body>
 
 </html>


### PR DESCRIPTION
### edit_form.css, edit_confirm.css の実装
cssはregist_form.css, regist_confirm.cssを流用しました。

### 更新処理完了メッセージのCSS実装
新規登録や編集を実行後に word_list 画面で表示する処理完了メッセージについて、
表示位置を mainContainer の枠外から、wordDetailContainer 内に変更しました。

### 削除確認モーダルの実装
カテゴリ・単語の削除ボタンをクリックした際に、
対応する各リスト位置の真下に削除確認を行うモーダルを表示する処理を追加しました。
ユーザが削除実行 or キャンセルを選べるようになりました。


