### PR TITLE
wordDetailの表示の際、relatedWordsの循環参照を防止するためWordDetailDtoクラスを作成

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordApiController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordApiController.java
@@ -1,7 +1,6 @@
 package com.example.demo.controller;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
@@ -13,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.demo.dto.WordDetailDto;
 import com.example.demo.dto.WordDto;
-import com.example.demo.entity.Word;
 import com.example.demo.service.CategoryService;
 import com.example.demo.service.WordService;
 
@@ -29,24 +28,33 @@ public class WordApiController {
 	private final WordService wordService;
 	private final CategoryService categoryService;
 	
+	// 単語一覧を表示
 	@GetMapping("/words")
 	public List<WordDto> getWordsByCategoryId(@RequestParam("categoryId") Integer categoryId){
 		return wordService.findWordsByCategoryId(categoryId);
 	}
+
+	
+	// wordDetail表示
+	@GetMapping("/words/{id}")
+	public ResponseEntity<WordDetailDto> getDetail(@PathVariable("id") Integer id,Model model) {
+		WordDetailDto dto = wordService.findWordDetailDtoById(id);
+		if(dto == null) {
+			return ResponseEntity.notFound().build();
+		}
+		return ResponseEntity.ok(dto);
+	}
+	
+	
+	// カテゴリ削除
 	@DeleteMapping("/categories/{id}")
 	@ResponseBody
 	public ResponseEntity<Void> deleteCategory(@PathVariable("id") Integer id) {
 	    categoryService.deleteByCategoryId(id);
 	    return ResponseEntity.ok().build();
 	}
-	@GetMapping("/words/{id}")
-	public ResponseEntity<Object> getDetail(@PathVariable("id") Integer id,Model model) {
-		Optional<Word> wordOpt = wordService.findById(id);
-		if(wordOpt.isEmpty()) {
-			return ResponseEntity.notFound().build();
-		}
-		return ResponseEntity.ok(wordOpt.get());
-	}
+	
+	// 単語削除
 	@DeleteMapping("/words/{id}")
 	public ResponseEntity<Void> deleteWord(@PathVariable("id") Integer id) {
 	    boolean deleted = wordService.deleteById(id);

--- a/KnowledgeMap/src/main/java/com/example/demo/dto/WordDetailDto.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/dto/WordDetailDto.java
@@ -1,0 +1,17 @@
+package com.example.demo.dto;
+
+import java.util.List;
+
+import com.example.demo.entity.Category;
+
+import lombok.Data;
+//「単語一覧から単語をクリックした時に表示する単語詳細」 のデータを取得するための DTO
+@Data
+public class WordDetailDto {
+	private Integer id;
+	private String wordName;
+	private String content;
+	private Category category;
+	private List<WordDto> relatedWords;
+	
+}

--- a/KnowledgeMap/src/main/java/com/example/demo/dto/WordDto.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/dto/WordDto.java
@@ -1,7 +1,7 @@
 package com.example.demo.dto;
 
 import lombok.Data;
-
+// 「カテゴリをクリックしたときに表示する単語一覧」 のデータを取得するための 単語DTO
 @Data
 public class WordDto {
 	    private Integer id;

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
@@ -3,6 +3,7 @@ package com.example.demo.service;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.demo.dto.WordDetailDto;
 import com.example.demo.dto.WordDto;
 import com.example.demo.entity.Word;
 import com.example.demo.form.WordForm;
@@ -17,5 +18,6 @@ public interface WordService {
     public Word updateWord(Integer id, WordForm wordForm);
     public List<WordDto> findWordsByCategoryId(Integer id);
     public List<String> getRelatedWordNames(WordForm wordForm);
+    public WordDetailDto findWordDetailDtoById(Integer id);
     
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.demo.dto.WordDetailDto;
 import com.example.demo.dto.WordDto;
 import com.example.demo.entity.Category;
 import com.example.demo.entity.Word;
@@ -27,24 +28,24 @@ public class WordServiceImpl implements WordService {
 
 	// WordForm型からWord型への変換を行うユーティリティメソッド
 	public void transferWordFormToWord(Word word, WordForm wordForm) {
-//		word.setId(wordForm.getId());
+		//		word.setId(wordForm.getId());
 		word.setWordName(wordForm.getWordName());
 		word.setContent(wordForm.getContent());
 		// wordForm型の categoryId から Category型に変換して Word型にセット
 		Optional<Category> categoryOpt = categoryRepository.findById(wordForm.getCategoryId());
-		if(categoryOpt.isPresent()) {
-			word.setCategory(categoryOpt.get());			
+		if (categoryOpt.isPresent()) {
+			word.setCategory(categoryOpt.get());
 		}
-		if(wordForm.getRelatedWordIds() != null) {
-			
-		//@ManyToManyのついてるフィールドは、Hibernateが内部で clear()やadd()を行う可能性があるので mutable である必要がある
-		// .toList()はimmutableとなり、clear()が呼ばれたときにjava.lang.UnsupportedOperationExceptionが発生する
-		List<Word> relatedWords = wordForm.getRelatedWordIds().stream()
-				.map(wordId -> wordRepository.findById(wordId))
-				.filter(opt -> opt.isPresent())
-				.map(opt -> opt.get())
-				.collect(Collectors.toCollection(ArrayList::new));
-		word.setRelatedWords(relatedWords);
+		if (wordForm.getRelatedWordIds() != null) {
+
+			//@ManyToManyのついてるフィールドは、Hibernateが内部で clear()やadd()を行う可能性があるので mutable である必要がある
+			// .toList()はimmutableとなり、clear()が呼ばれたときにjava.lang.UnsupportedOperationExceptionが発生する
+			List<Word> relatedWords = wordForm.getRelatedWordIds().stream()
+					.map(wordId -> wordRepository.findById(wordId))
+					.filter(opt -> opt.isPresent())
+					.map(opt -> opt.get())
+					.collect(Collectors.toCollection(ArrayList::new));
+			word.setRelatedWords(relatedWords);
 		}
 	}
 
@@ -61,27 +62,56 @@ public class WordServiceImpl implements WordService {
 	public List<Word> findAll() {
 		return wordRepository.findAll();
 	}
+
 	@Override
 	public Optional<Word> findById(Integer id) {
 		return wordRepository.findById(id);
-	}	
+	}
+	// wordDetail表示
+	@Override
+	public WordDetailDto findWordDetailDtoById(Integer id) {
+		Optional<Word> wordOpt = wordRepository.findById(id);
+		WordDetailDto dto = new WordDetailDto();
+		if (wordOpt.isPresent()) {
+			Word word = wordOpt.get();
+			dto.setId(word.getId());
+			dto.setWordName(word.getWordName());
+			dto.setContent(word.getContent());
+			dto.setCategory(word.getCategory());
+			
+			List<WordDto> relatedWords = new ArrayList<>();
+			for (Word relatedWord : word.getRelatedWords()) {
+				WordDto wordDto = new WordDto();
+				wordDto.setId(relatedWord.getId());
+				wordDto.setWordName(relatedWord.getWordName());
+				wordDto.setCategoryId(relatedWord.getCategory().getId());
+				relatedWords.add(wordDto);
+			}
+
+			dto.setRelatedWords(relatedWords);
+		}
+		return dto;
+	}
+
 	@Override
 	public Optional<Word> findByWordName(String name) {
 		return wordRepository.findByWordName(name);
 	}
+
 	@Override
 	public List<WordDto> findWordsByCategoryId(Integer categoryId) {
-	    return wordRepository.findByCategoryId(categoryId).stream()
-	        .map(word -> {
-	            WordDto dto = new WordDto();
-	            dto.setId(word.getId());
-	            dto.setWordName(word.getWordName());
-	            dto.setContent(word.getContent());
-	            dto.setCategoryId(word.getCategory().getId());
-	            return dto;
-	        })
-	        .toList();
+		return wordRepository.findByCategoryId(categoryId).stream()
+				.map(word -> {
+					WordDto dto = new WordDto();
+					dto.setId(word.getId());
+					dto.setWordName(word.getWordName());
+					dto.setContent(word.getContent());
+					dto.setCategoryId(word.getCategory().getId());
+					return dto;
+				})
+				.toList();
 	}
+
 	@Override
 	@Transactional
 	//関連語テーブルから削除してからwordテーブルから削除する
@@ -94,16 +124,22 @@ public class WordServiceImpl implements WordService {
 		wordRepository.deleteById(id);
 		return true;
 	}
-	@Override
-	public Word addWord(WordForm wordForm) {
-		Word word = new Word();
-		transferWordFormToWord(word,wordForm);
-		Word savedWord = wordRepository.save(word);
-		//関連語にも新規作成した単語を関連づける
-		for(Word relatedWord : savedWord.getRelatedWords()) {
+
+	//関連語にも新規作成した単語を関連づけるメソッド
+	public void interactRelatedWord(Word savedWord) {
+		for (Word relatedWord : savedWord.getRelatedWords()) {
 			relatedWord.getRelatedWords().add(savedWord);
 			wordRepository.save(relatedWord);
 		}
+	}
+
+	@Override
+	public Word addWord(WordForm wordForm) {
+		Word word = new Word();
+		transferWordFormToWord(word, wordForm);
+		Word savedWord = wordRepository.save(word);
+		//関連語の相互参照
+		interactRelatedWord(savedWord);
 		return savedWord;
 	}
 
@@ -112,7 +148,10 @@ public class WordServiceImpl implements WordService {
 		Optional<Word> wordOpt = wordRepository.findById(id);
 		Word word = wordOpt.get();
 		transferWordFormToWord(word, wordForm);//WordForm型 -> Word型　の変換
-		return  wordRepository.save(word);
+		Word updatedWord = wordRepository.save(word);
+		//関連語の相互参照
+		interactRelatedWord(updatedWord);
+		return updatedWord;
 	}
 
 }

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -64,6 +64,7 @@ function setCategorySelection(categoryId) {
 // 選択中の単語の色変更
 function setWordSelection(wordId) {
 	const wordBtns = document.querySelectorAll(".wordBtn");
+	console.log([...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") == wordId));
 	[...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") == wordId)
 		.classList.add("wordBtnSelected");
 }
@@ -178,21 +179,27 @@ async function showWordDetail(wordId) {
 			if (wordDetail.relatedWords && wordDetail.relatedWords.length > 0) {
 				const relatedWordsContainer = document.createElement("div");
 				relatedWordsContainer.classList.add("relatedWords")
+				
 				const reference = document.createElement("span");
 				reference.textContent = "参照：";
+				
 				const relatedWords = document.createElement("ul");
 				for (const relatedWord of wordDetail.relatedWords) {
 					const li = document.createElement("li");
-					li.textContent = relatedWord.wordName;
-					//関連語の相互参照
+					li.textContent = relatedWord.wordName;			
+					//関連語の相互参照リンク作成
 					li.addEventListener("click",async()=>{ 
+						//カテゴリ一覧の設定
 						clearCategorySelection();
-						setCategorySelection(relatedWord.category.id);
+						setCategorySelection(relatedWord.categoryId);
+						//単語一覧の設定
 						wordListContainer.innerHTML = "";
-						showWordList(relatedWord.category.id);
+						await showWordList(relatedWord.categoryId);
+						setWordSelection(relatedWord.id);
+						//wordDetailの表示
 						wordDetailContainer.innerHTML="";
-						showWordDetail(relatedWord.id)});
-						
+						showWordDetail(relatedWord.id);
+					});					
 					relatedWords.appendChild(li);
 				}
 				relatedWordsContainer.append(reference, relatedWords);


### PR DESCRIPTION
### wordDetail表示内の関連語の表示を修正

#### これまで
wordDetail表示の際にエンティティ（Wordクラス）をそのまま渡していたため、
relatedWordsにおいて自己参照が発生し、
@JsonIdentityInfoによる循環参照回避も不完全だった。

#### 修正後
WordDetailDtoクラスを作成し、relatedWordsはList<WordDto>で管理