### PR TITLE
Feature/#79 word list

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordController.java
@@ -25,7 +25,7 @@ import com.example.demo.validator.WordFormValidator;
 import lombok.RequiredArgsConstructor;
 
 @Controller
-@RequestMapping("/wordbooks/{wordBookId}")
+@RequestMapping("/wordbooks/{wordbookId}/wordList")
 @RequiredArgsConstructor
 public class WordController {
 	private final WordService wordService;
@@ -38,15 +38,16 @@ public class WordController {
 	}
 
 	// word一覧表示
-	@GetMapping("/words")
-	public String showWordList(Model model,@PathVariable Integer wordBookId) {
-		model.addAttribute("categories", categoryService.findAll());
+	@GetMapping("")
+	public String showWordList(Model model,@PathVariable("wordbookId") Integer wordbookId) {
+		model.addAttribute("categories", categoryService.findByWordbookId(wordbookId));
+		model.addAttribute("wordbookId",wordbookId);
 		return "word_list";
 	}
 
 	//新規登録画面
 	@GetMapping("/showWordForm")
-	public String showWordForm(Model model) {
+	public String showWordForm(Model model,@PathVariable("wordbookId") Integer wordbookId) {
 		model.addAttribute("wordForm", new WordForm());
 		model.addAttribute("wordList", wordService.findAll());
 		model.addAttribute("categories", categoryService.findAll());
@@ -54,8 +55,11 @@ public class WordController {
 	}
 
 	// 登録画面へ戻るとき
-	@PostMapping("showWordForm")
-	public String backToWordForm(@ModelAttribute("wordForm") WordForm wordForm, Model model) {
+	@PostMapping("/showWordForm")
+	public String backToWordForm(
+			@ModelAttribute("wordForm") WordForm wordForm,
+			@PathVariable("wordbookId") Integer wordbookId,
+			Model model) {
 		model.addAttribute("wordList", wordService.findAll());
 		model.addAttribute("categories", categoryService.findAll());
 		return "regist_form";
@@ -66,6 +70,7 @@ public class WordController {
 	public String registConfirm(
 			@ModelAttribute("wordForm") @Validated WordForm wordForm,
 			BindingResult result,
+			@PathVariable("wordbookId") Integer wordbookId,
 			Model model) {
 		if (result.hasErrors()) {
 			model.addAttribute("categories", categoryService.findAll());
@@ -103,7 +108,9 @@ public class WordController {
 
 	//DB新規登録
 	@PostMapping("/regist")
-	public String regist(WordForm wordForm, RedirectAttributes redirectAttribute) {
+	public String regist(WordForm wordForm,
+			@PathVariable("wordbookId") Integer wordbookId,
+			RedirectAttributes redirectAttribute) {
 		
 		System.out.println("■ ■ ■ ■ ■ ■ ■ " +wordForm.getCategoryId());
 		// 存在しないカテゴリの場合エラー
@@ -117,7 +124,7 @@ public class WordController {
 		System.out.println("■ ■ ■ ■ ■ ■ ■ " +registedWord.getCategory().getId());
 		redirectAttribute.addFlashAttribute("regist_ok", "登録しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
-		return String.format("redirect:/wordList?categoryId=%d&id=%d", registedWord.getCategory().getId(),
+		return String.format("redirect:/wordbooks/%d/wordList?categoryId=%d&id=%d", wordbookId,registedWord.getCategory().getId(),
 				registedWord.getId());
 	}
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -68,7 +68,7 @@ public class WordDetailController {
 		wordForm.setRelatedWordIds(relatedWordIds);
 		model.addAttribute("relatedWordNames", wordService.getRelatedWordNames(wordForm));
 		model.addAttribute("categories", categoryService.findByWordbookId(wordbookId));
-		model.addAttribute("wordList", wordService.findAll());
+		model.addAttribute("wordList", wordService.findByWordbookId(wordbookId));
 		model.addAttribute("word", word);
 
 		return "edit_form";
@@ -85,8 +85,8 @@ public class WordDetailController {
 		if(fromRegist != null) {
 			model.addAttribute("fromRegist", fromRegist);
 		}	
-		model.addAttribute("categories", categoryService.findAll());
-		model.addAttribute("wordList", wordService.findAll());
+		model.addAttribute("categories", categoryService.findByWordbookId(wordbookId));
+		model.addAttribute("wordList", wordService.findByWordbookId(wordbookId));
 		model.addAttribute("relatedWordNames", wordService.getRelatedWordNames(wordForm));
 
 		Optional<Word> wordOpt = wordService.findById(wordId);
@@ -117,9 +117,8 @@ public class WordDetailController {
 		Word word = wordOpt.get();
 		//バリデーションチェック
 		if (result.hasErrors()) {
-			System.out.println("■ ■ ■ ■ バリデーションエラーに到達");
 			model.addAttribute("categories", categoryService.findByWordbookId(wordbookId));
-			model.addAttribute("wordList", wordService.findAll());
+			model.addAttribute("wordList", wordService.findByWordbookId(wordbookId));
 			model.addAttribute("relatedWordNames", wordService.getRelatedWordNames(wordForm));
 			model.addAttribute("word", word);
 			return "edit_form";
@@ -127,7 +126,7 @@ public class WordDetailController {
 		String newCategoryName = wordForm.getCategoryName();
 		// categoryNameに入力があった場合
 		if (newCategoryName != null && !newCategoryName.isBlank()) {
-			Optional<Category> categoryOpt = categoryService.findByName(newCategoryName);
+			Optional<Category> categoryOpt = categoryService.findByNameAndWordbookId(newCategoryName,wordbookId);
 			if (categoryOpt.isEmpty()) { // 入力されたcategoryNameが未登録 -> categoryテーブルへ新規登録
 				try {
 					Category registedCategory = categoryService.addCategory(newCategoryName,wordbookId);
@@ -135,8 +134,8 @@ public class WordDetailController {
 				}catch(IllegalArgumentException e) {
 					//System.err.println("カテゴリ追加エラー: " + e.getMessage());
 					model.addAttribute("category_add_error", "カテゴリの追加に失敗しました");
-					model.addAttribute("categories", categoryService.findAll());
-					model.addAttribute("wordList", wordService.findAll());
+					model.addAttribute("categories", categoryService.findByWordbookId(wordbookId));
+					model.addAttribute("wordList", wordService.findByWordbookId(wordbookId));
 					model.addAttribute("relatedWordNames", wordService.getRelatedWordNames(wordForm));
 					model.addAttribute("word", wordService.findById(wordForm.getId()).orElse(null));
 					return "edit_form";
@@ -164,7 +163,7 @@ public class WordDetailController {
 			RedirectAttributes redirectAttribute) {
 		Word updatedWord = wordService.updateWord(wordId, wordForm);
 		redirectAttribute.addFlashAttribute("edit_ok", "編集しました");
-		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
+		redirectAttribute.addFlashAttribute("wordList", wordService.findByWordbookId(wordbookId));
 		return String.format("redirect:/wordbooks/%d/wordList?categoryId=%d&id=%d", wordbookId, updatedWord.getCategory().getId(), updatedWord.getId());
 	}
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordDetailController.java
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("words")
+@RequestMapping("/wordbooks/{wordbookId}/wordList")
 public class WordDetailController {
 	private final WordService wordService;
 	private final CategoryService categoryService;
@@ -39,15 +39,16 @@ public class WordDetailController {
 		webDataBinder.addValidators(wordFormValidator);
 	}
 
-	//word編集画面
-	@GetMapping("/{id}/editForm")
-	public String showEditForm(
-			@PathVariable("id") Integer id,
+	//word編集画面( word_listからの遷移 )
+	@GetMapping("/{wordId}/editForm")
+	public String showEditFormFromWordList(
+			@PathVariable("wordId") Integer wordId,
+			@PathVariable("wordbookId") Integer wordbookId,
 			//新規登録の確認画面からの遷移であるフラグ
 			@RequestParam(name = "fromRegist", required = false) String fromRegist,
 			@ModelAttribute WordForm wordForm,
 			Model model) {
-		Optional<Word> wordOpt = wordService.findById(id);
+		Optional<Word> wordOpt = wordService.findById(wordId);
 		if (wordOpt.isEmpty()) {
 			return "edit_error";
 		}
@@ -72,26 +73,51 @@ public class WordDetailController {
 
 		return "edit_form";
 	}
+	//word編集画面( edit_confirmからの遷移 ) 
+	@PostMapping("/{wordId}/editForm")
+	public String showEditFormFromEditConfirm(
+			@PathVariable("wordId") Integer wordId,
+			@PathVariable("wordbookId") Integer wordbookId,
+			//新規登録の確認画面からの遷移であるフラグ
+			@RequestParam(name = "fromRegist", required = false) String fromRegist,
+			@ModelAttribute WordForm wordForm,
+			Model model) {
+		if(fromRegist != null) {
+			model.addAttribute("fromRegist", fromRegist);
+		}	
+		model.addAttribute("categories", categoryService.findAll());
+		model.addAttribute("wordList", wordService.findAll());
+		model.addAttribute("relatedWordNames", wordService.getRelatedWordNames(wordForm));
+
+		Optional<Word> wordOpt = wordService.findById(wordId);
+		wordOpt.ifPresent(word -> model.addAttribute("word", word));
+		return "edit_form";
+	}
+	
 
 	//word編集確認
-	@PostMapping("/{id}/editConfirm")
+	@PostMapping("/{wordId}/editConfirm")
 	public String editConfirm(
 			@Validated WordForm wordForm,
 			BindingResult result,
 			Model model,
-			@PathVariable("id") Integer id,
+			@PathVariable("wordId") Integer wordId,
+			@PathVariable("wordbookId") Integer wordbookId,
 			@RequestParam(name = "fromRegist", required = false) String fromRegist) {
+
+
 		//新規登録から遷移した場合 戻るボタンの種類を切り替えるためのフラグを用意
 		if (fromRegist != null) {
 			model.addAttribute("fromRegist", "fromRegist");
 		}
-		Optional<Word> wordOpt = wordService.findById(id);
+		Optional<Word> wordOpt = wordService.findById(wordId);
 		if (wordOpt.isEmpty()) {
 			return "edit_error";
 		}
 		Word word = wordOpt.get();
 		//バリデーションチェック
 		if (result.hasErrors()) {
+			System.out.println("■ ■ ■ ■ バリデーションエラーに到達");
 			model.addAttribute("categories", categoryService.findAll());
 			model.addAttribute("wordList", wordService.findAll());
 			model.addAttribute("relatedWordNames", wordService.getRelatedWordNames(wordForm));
@@ -121,13 +147,14 @@ public class WordDetailController {
 		return "edit_confirm";
 	}
 
-	@PostMapping("/{id}/edit")
+	@PostMapping("/{wordId}/edit")
 	public String edit(@ModelAttribute WordForm wordForm,
-			@PathVariable("id") Integer id,
+			@PathVariable("wordId") Integer wordId,
+			@PathVariable("wordbookId") Integer wordbookId,
 			RedirectAttributes redirectAttribute) {
-		Word updatedWord = wordService.updateWord(id, wordForm);
+		Word updatedWord = wordService.updateWord(wordId, wordForm);
 		redirectAttribute.addFlashAttribute("edit_ok", "編集しました");
 		redirectAttribute.addFlashAttribute("wordList", wordService.findAll());
-		return String.format("redirect:/wordList?categoryId=%d&id=%d", updatedWord.getCategory().getId(),updatedWord.getId());
+		return String.format("redirect:/wordbooks/%d/wordList?categoryId=%d&id=%d", wordbookId, updatedWord.getCategory().getId(), updatedWord.getId());
 	}
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/dto/CategoryDto.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/dto/CategoryDto.java
@@ -1,0 +1,10 @@
+package com.example.demo.dto;
+
+import lombok.Data;
+
+@Data
+public class CategoryDto {
+	private Integer id;
+	private String name;
+
+}

--- a/KnowledgeMap/src/main/java/com/example/demo/dto/WordDetailDto.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/dto/WordDetailDto.java
@@ -2,8 +2,6 @@ package com.example.demo.dto;
 
 import java.util.List;
 
-import com.example.demo.entity.Category;
-
 import lombok.Data;
 //「単語一覧から単語をクリックした時に表示する単語詳細」 のデータを取得するための DTO
 @Data
@@ -11,7 +9,8 @@ public class WordDetailDto {
 	private Integer id;
 	private String wordName;
 	private String content;
-	private Category category;
+	//無限ループ防止のためカテゴリはDTOに変更(変数名はcategoryのまま)
+	private CategoryDto category;
 	private List<WordDto> relatedWords;
 	
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/entity/Word.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/entity/Word.java
@@ -66,6 +66,10 @@ public class Word {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
     
+    @ManyToOne
+    @JoinColumn(name="wordbook_id",nullable = false)
+    private Wordbook wordbook;
+    
     //word_relationテーブルとのマッピング
     @ManyToMany
     @JoinTable(
@@ -74,4 +78,8 @@ public class Word {
         inverseJoinColumns = @JoinColumn(name = "related_word_id")
     )
     private List<Word> relatedWords;
+    
+    
+    
+    
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/entity/Wordbook.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/entity/Wordbook.java
@@ -34,5 +34,8 @@ public class Wordbook {
 	
 	@OneToMany(mappedBy="wordbook",cascade=CascadeType.ALL,orphanRemoval=true)
 	private List<Category> categories;
+	
+	@OneToMany(mappedBy="wordbook",cascade=CascadeType.ALL,orphanRemoval=true)
+	private List<Word> words;
 
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/form/WordForm.java
@@ -16,6 +16,7 @@ public class WordForm {
     private String content;
     private Integer categoryId;// カテゴリ選択用
 	private String categoryName;// カテゴリ新規登録用
+	private Integer wordbookId;
     private List<Integer> relatedWordIds;// 関連語（複数選択）
     
     @AssertTrue(message="カテゴリが選択されていません")

--- a/KnowledgeMap/src/main/java/com/example/demo/repository/CategoryRepository.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/repository/CategoryRepository.java
@@ -9,6 +9,8 @@ import com.example.demo.entity.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Integer> {
 	Optional<Category> findByName(String name);
+	Optional<Category> findByNameAndWordbookId(String name,Integer wordbookId);
+	
 	List<Category> findByWordbookId(Integer wordbookId);
 }
 

--- a/KnowledgeMap/src/main/java/com/example/demo/repository/WordRepository.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/repository/WordRepository.java
@@ -10,6 +10,8 @@ import com.example.demo.entity.Word;
 public interface WordRepository extends JpaRepository<Word, Integer> {
     Optional<Word> findByWordName(String name);
     List<Word> findByCategoryId(Integer categoryId);
+    List<Word> findByWordbookId(Integer wordbookId);
+    Optional<Word> findByWordNameAndWordbookId(String name,Integer wordbookId);
     
 }
 

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
@@ -11,5 +11,6 @@ public interface CategoryService {
 	Optional<Category> findByCategoryId(Integer categoryId);
 	Category addCategory(String categoryName,Integer wordbookId);
 	Optional<Category> findByName(String categoryName);
+	Optional<Category> findByNameAndWordbookId(String categoryName,Integer wordbookId);
 	void deleteByCategoryId(Integer categoryId);
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryService.java
@@ -9,7 +9,7 @@ public interface CategoryService {
 	List<Category> findAll();
 	List<Category> findByWordbookId(Integer wordbookId);
 	Optional<Category> findByCategoryId(Integer categoryId);
-	Category addCategory(String categoryName);
+	Category addCategory(String categoryName,Integer wordbookId);
 	Optional<Category> findByName(String categoryName);
 	void deleteByCategoryId(Integer categoryId);
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
@@ -34,6 +34,10 @@ public class CategoryServiceImpl implements CategoryService {
 	public Optional<Category> findByName(String categoryName) {
 		return categoryRepository.findByName(categoryName);
 	}
+	@Override
+	public Optional<Category> findByNameAndWordbookId(String categoryName,Integer wordbookId) {
+		return categoryRepository.findByNameAndWordbookId(categoryName,wordbookId);
+	}
 
 	@Override
 	public List<Category> findByWordbookId(Integer wordbookId) {

--- a/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/CategoryServiceImpl.java
@@ -6,45 +6,59 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 import com.example.demo.entity.Category;
+import com.example.demo.entity.Wordbook;
 import com.example.demo.repository.CategoryRepository;
+import com.example.demo.repository.WordbookRepository;
 
 import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class CategoryServiceImpl implements CategoryService {
-	
+
 	private final CategoryRepository categoryRepository;
-	
+	private final WordbookRepository wordbookRepository;
+
 	@Override
 	public List<Category> findAll() {
 		return categoryRepository.findAll();
 	}
+
 	@Override
 	public Optional<Category> findByCategoryId(Integer categoryId) {
-		Optional<Category>  categoryOpt = categoryRepository.findById(categoryId);
+		Optional<Category> categoryOpt = categoryRepository.findById(categoryId);
 		return categoryOpt;
 	}
+
 	@Override
 	public Optional<Category> findByName(String categoryName) {
 		return categoryRepository.findByName(categoryName);
 	}
-	
-	//nameで登録してそのidを返す
-	@Override
-	public Category addCategory(String categoryName) {
-		Category category = new Category();
-		category.setName(categoryName);
-		Category savedCategory = categoryRepository.save(category);
-		return savedCategory;
-	}
-	
-	@Override
-	public void deleteByCategoryId(Integer categoryId) {
-		categoryRepository.deleteById(categoryId);
-	}
+
 	@Override
 	public List<Category> findByWordbookId(Integer wordbookId) {
 		return categoryRepository.findByWordbookId(wordbookId);
+	}
+
+	//nameで登録してそのidを返す
+	@Override
+	public Category addCategory(String categoryName, Integer wordbookId) {
+		Category category = new Category();
+		Optional<Wordbook> wordbookOpt = wordbookRepository.findById(wordbookId);
+		if (wordbookOpt.isEmpty()) {
+			throw new IllegalArgumentException("指定されたwordbookIdが見つかりません" + wordbookId);
+		}
+		category.setName(categoryName);
+		category.setWordbook(wordbookOpt.get());
+		Category savedCategory = categoryRepository.save(category);
+		return savedCategory;
+	}
+
+
+
+	@Override
+	public void deleteByCategoryId(Integer categoryId) {
+		categoryRepository.deleteById(categoryId);
 	}
 
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordService.java
@@ -11,8 +11,10 @@ import com.example.demo.form.WordForm;
 public interface WordService {
 
 	Optional<Word> findByWordName(String name);
+	Optional<Word> findByWordNameAndWordbookId(String name,Integer wordbookId);
 	Word addWord(WordForm wordForm);
     List<Word> findAll();
+    List<Word> findByWordbookId(Integer wordbookId);
     Optional<Word> findById(Integer id);
     boolean deleteById(Integer id);
     Word updateWord(Integer id, WordForm wordForm);

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.demo.dto.CategoryDto;
 import com.example.demo.dto.WordDetailDto;
 import com.example.demo.dto.WordDto;
 import com.example.demo.entity.Category;
@@ -68,6 +69,7 @@ public class WordServiceImpl implements WordService {
 	public Optional<Word> findById(Integer id) {
 		return wordRepository.findById(id);
 	}
+
 	// wordDetail表示
 	@Override
 	public WordDetailDto findWordDetailDtoById(Integer id) {
@@ -75,11 +77,16 @@ public class WordServiceImpl implements WordService {
 		WordDetailDto dto = new WordDetailDto();
 		if (wordOpt.isPresent()) {
 			Word word = wordOpt.get();
+
+			CategoryDto categoryDto = new CategoryDto();
+			categoryDto.setId(word.getCategory().getId());
+			categoryDto.setName(word.getCategory().getName());
+
 			dto.setId(word.getId());
 			dto.setWordName(word.getWordName());
 			dto.setContent(word.getContent());
-			dto.setCategory(word.getCategory());
-			
+			dto.setCategory(categoryDto);
+
 			List<WordDto> relatedWords = new ArrayList<>();
 			for (Word relatedWord : word.getRelatedWords()) {
 				WordDto wordDto = new WordDto();

--- a/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/service/WordServiceImpl.java
@@ -13,10 +13,12 @@ import com.example.demo.dto.WordDetailDto;
 import com.example.demo.dto.WordDto;
 import com.example.demo.entity.Category;
 import com.example.demo.entity.Word;
+import com.example.demo.entity.Wordbook;
 import com.example.demo.form.WordForm;
 import com.example.demo.repository.CategoryRepository;
 import com.example.demo.repository.WordRelationRepository;
 import com.example.demo.repository.WordRepository;
+import com.example.demo.repository.WordbookRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +28,7 @@ public class WordServiceImpl implements WordService {
 	private final WordRepository wordRepository;
 	private final CategoryRepository categoryRepository;
 	private final WordRelationRepository wordRelationRepository;
+	private final WordbookRepository wordbookRepository;
 
 	// WordForm型からWord型への変換を行うユーティリティメソッド
 	public void transferWordFormToWord(Word word, WordForm wordForm) {
@@ -36,6 +39,10 @@ public class WordServiceImpl implements WordService {
 		Optional<Category> categoryOpt = categoryRepository.findById(wordForm.getCategoryId());
 		if (categoryOpt.isPresent()) {
 			word.setCategory(categoryOpt.get());
+		}
+		Optional<Wordbook> wordbookOpt = wordbookRepository.findById(wordForm.getWordbookId());
+		if(wordbookOpt.isPresent()) {
+			word.setWordbook(wordbookOpt.get());
 		}
 		if (wordForm.getRelatedWordIds() != null) {
 
@@ -105,6 +112,10 @@ public class WordServiceImpl implements WordService {
 	public Optional<Word> findByWordName(String name) {
 		return wordRepository.findByWordName(name);
 	}
+	@Override
+	public Optional<Word> findByWordNameAndWordbookId(String name,Integer wordbookId) {
+		return wordRepository.findByWordNameAndWordbookId(name,wordbookId);
+	}
 
 	@Override
 	public List<WordDto> findWordsByCategoryId(Integer categoryId) {
@@ -118,6 +129,11 @@ public class WordServiceImpl implements WordService {
 					return dto;
 				})
 				.toList();
+	}
+
+	@Override
+	public List<Word> findByWordbookId(Integer wordbookId) {
+		return wordRepository.findByWordbookId(wordbookId);
 	}
 
 	@Override
@@ -161,5 +177,6 @@ public class WordServiceImpl implements WordService {
 		interactRelatedWord(updatedWord);
 		return updatedWord;
 	}
+
 
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
@@ -37,22 +37,35 @@ public class WordFormValidator implements Validator {
 				errors.rejectValue("relatedWordIds", null, "自身の単語は関連語として登録できません");
 			}
 		}
-		// 既存wordNameならエラー
+		//既存のwordNameで登録しようとするとエラー
 		Optional<Word> existingWordOpt = wordService.findByWordName(wordForm.getWordName());
+		Integer wordFormId = wordForm.getId();
+		// wordNameが既存
 		if (existingWordOpt.isPresent()) {
-			Word existingWord = existingWordOpt.get();
-			//   wordNameによる検索で既存だった  かつ  新規登録の時
-			//					または
-			//   wordNameによる検索で既存だった  かつ  既存のwordを編集の時
-			//   ( 編集対象のwordは wordNameによる検索で見つかったword と同じidである必要がある)
-			if (wordForm.getId() == null || !wordForm.getId().equals(existingWord.getId())) {
-//				errors.rejectValue("wordName", null, wordForm.getWordName() + "は既に登録されています");
-				errors.rejectValue("wordName", null, "はすでに登録されています");
-			}
+		    Word existingWord = existingWordOpt.get();
+		    // 新規登録時( = wordFormIdがない)
+		    if (wordFormId == null) {
+		        errors.rejectValue("wordName", null, "はすでに登録されています");
+	        // 編集時 ( = wordFormIdがあり、かつ、wordFormIdは既存wordのIdと異なる)
+		    } else if (!wordFormId.equals(existingWord.getId())) {
+		        errors.rejectValue("wordName", null, "はすでに登録されています");
+		    }
 		}
+//		 wordName に一致する単語がすでに存在する場合
+//		 かつ、現在の編集がその単語自身ではない（＝他人と重複）または新規登録の場合はエラー
+//		 ( 編集対象のwordは wordNameによる検索で見つかったword と同じidである必要がある )
+//				if (existingWordOpt.isPresent()) {
+//			Word existingWord = existingWordOpt.get();
+//			
+//			if (wordForm.getId() == null || !wordForm.getId().equals(existingWord.getId())) {
+//				errors.rejectValue("wordName", null, "はすでに登録されています");//wordNameはHTMLで埋め込む
+//			}
+//		}
+		
 		//categoryIdとcategoryNameの両方に入力があればエラー
 		if(wordForm.getCategoryId() != null && wordForm.getCategoryName() != null && !wordForm.getCategoryName().isBlank()) {
 			errors.rejectValue("categoryId", null,"新規カテゴリを入力した場合は、カテゴリを選択できません");
 		}
+
 	}
 }

--- a/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/validator/WordFormValidator.java
@@ -38,33 +38,37 @@ public class WordFormValidator implements Validator {
 			}
 		}
 		//既存のwordNameで登録しようとするとエラー
-		Optional<Word> existingWordOpt = wordService.findByWordName(wordForm.getWordName());
+		Optional<Word> existingWordOpt = wordService.findByWordNameAndWordbookId(wordForm.getWordName(),wordForm.getWordbookId());
 		Integer wordFormId = wordForm.getId();
 		// wordNameが既存
 		if (existingWordOpt.isPresent()) {
-		    Word existingWord = existingWordOpt.get();
-		    // 新規登録時( = wordFormIdがない)
-		    if (wordFormId == null) {
-		        errors.rejectValue("wordName", null, "はすでに登録されています");
-	        // 編集時 ( = wordFormIdがあり、かつ、wordFormIdは既存wordのIdと異なる)
-		    } else if (!wordFormId.equals(existingWord.getId())) {
-		        errors.rejectValue("wordName", null, "はすでに登録されています");
-		    }
+			Word existingWord = existingWordOpt.get();
+			// 新規登録時( = wordFormIdがない)
+			if (wordFormId == null) {
+				errors.rejectValue("wordName", null, "はすでに登録されています");
+				// 編集時 ( = wordFormIdがあり、かつ、wordFormIdは既存wordのIdと異なる)
+			} else if (!wordFormId.equals(existingWord.getId())) {
+				errors.rejectValue("wordName", null, "はすでに登録されています");
+			}
 		}
-//		 wordName に一致する単語がすでに存在する場合
-//		 かつ、現在の編集がその単語自身ではない（＝他人と重複）または新規登録の場合はエラー
-//		 ( 編集対象のwordは wordNameによる検索で見つかったword と同じidである必要がある )
-//				if (existingWordOpt.isPresent()) {
-//			Word existingWord = existingWordOpt.get();
-//			
-//			if (wordForm.getId() == null || !wordForm.getId().equals(existingWord.getId())) {
-//				errors.rejectValue("wordName", null, "はすでに登録されています");//wordNameはHTMLで埋め込む
-//			}
-//		}
-		
+
+		//		 wordName に一致する単語がすでに存在する場合
+		//		 かつ、現在の編集がその単語自身ではない（＝他人と重複）または新規登録の場合はエラー
+		//		 ( 編集対象のwordは wordNameによる検索で見つかったword と同じidである必要がある )
+		//				if (existingWordOpt.isPresent()) {
+		//			Word existingWord = existingWordOpt.get();
+		//			
+		//			if (wordForm.getId() == null || !wordForm.getId().equals(existingWord.getId())) {
+		//				errors.rejectValue("wordName", null, "はすでに登録されています");//wordNameはHTMLで埋め込む
+		//			}
+		//		}
+
 		//categoryIdとcategoryNameの両方に入力があればエラー
-		if(wordForm.getCategoryId() != null && wordForm.getCategoryName() != null && !wordForm.getCategoryName().isBlank()) {
-			errors.rejectValue("categoryId", null,"新規カテゴリを入力した場合は、カテゴリを選択できません");
+		if (wordForm.getCategoryId() != null && wordForm.getCategoryName() != null
+				&& !wordForm.getCategoryName().isBlank())
+
+		{
+			errors.rejectValue("categoryId", null, "新規カテゴリを入力した場合は、カテゴリを選択できません");
 		}
 
 	}

--- a/KnowledgeMap/src/main/resources/static/css/login.css
+++ b/KnowledgeMap/src/main/resources/static/css/login.css
@@ -1,0 +1,11 @@
+@charset "UTF-8";
+.inputContainer{
+	margin: 0 auto;
+	width: fit-content;
+}
+label{
+	display: block;
+	text-align: end;
+	margin:2rem
+}
+

--- a/KnowledgeMap/src/main/resources/static/css/wordbook_list.css
+++ b/KnowledgeMap/src/main/resources/static/css/wordbook_list.css
@@ -1,0 +1,33 @@
+@charset "UTF-8";
+
+.wordbookList {
+	width: 40%;
+	max-width: 800px;
+	min-width: 500px;
+	background-color: var(--container-bg-color);
+	border: 1px solid var(--line-color);
+	border-radius: 10px;
+	padding: 2rem;
+	text-align: center;
+
+}
+
+.wordbookList li a {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 1rem;
+	height: 3rem;
+	text-decoration: none;
+	color: var(--main-text-color);
+	font-size: 1rem;
+	transition: all ease 0.3s;
+}
+
+.wordbookList li a:hover {
+	color: white;
+	background-color:var(--main-text-color);
+	border-radius: 5px;
+	font-size: 	1.2rem;
+	transform: scale(1.05);
+}

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -16,8 +16,7 @@ const deleteNgBtn = document.getElementById("deleteNg");
 let eventHandler = null;
 //単語帳idの取得
 const wordbookId = wordDetailContainer.dataset.wordbookId;
-console.log(typeof wordbookId);
-console.log(wordbookId);
+
 
 /*
 	新規登録または編集を実行後にword_listに戻ると
@@ -61,9 +60,9 @@ function clearCategorySelection() {
 }
 // 選択中カテゴリの色変更
 function setCategorySelection(categoryId) {
-	[...categoryBtns].find(btn => btn.getAttribute("data-id") == categoryId)
-		.classList.add("categoryBtnSelected");
-		
+	const updatedCategoryBtns = document.querySelectorAll(".categoryBtn");
+	[...updatedCategoryBtns].find(btn => btn.getAttribute("data-id") == categoryId)
+		.classList.add("categoryBtnSelected");		
 }
 // 選択中の単語の色変更
 function setWordSelection(wordId) {

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -14,6 +14,10 @@ const deleteOkBtn = document.getElementById("deleteOk");
 const deleteNgBtn = document.getElementById("deleteNg");
 //モーダル外側をクリックしたときに発生するイベントハンドラ(モーダルを閉じる処理を行う)
 let eventHandler = null;
+//単語帳idの取得
+const wordbookId = wordDetailContainer.dataset.wordbookId;
+console.log(typeof wordbookId);
+console.log(wordbookId);
 
 /*
 	新規登録または編集を実行後にword_listに戻ると
@@ -156,7 +160,7 @@ async function showWordDetail(wordId) {
 			span.classList.add("bi-pencil-fill");
 			editBtn.append(span);
 			editBtn.addEventListener("click", () => {
-				location.href = `/words/${wordId}/editForm`;
+				location.href = `/wordbooks/${wordbookId}/wordList/${wordId}/editForm`;
 			})
 			wordNameContainer.append(wordName, editBtn);
 			//カテゴリ

--- a/KnowledgeMap/src/main/resources/templates/edit_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_confirm.html
@@ -15,7 +15,10 @@
 <body>
 	<h1>edit_confirm</h1>
 	<h2>以下の内容で編集します</h2>
-	<form class="commonForm" th:action="@{/words/{id}/edit(id=${word.id})}" method="post" th:object="${wordForm}">
+	<form  th:action="@{/wordbooks/{wordbookId}/wordList/{wordId}/edit(wordbookId=${wordbookId},wordId=${word.id})}" 
+		   class="commonForm"
+		   method="post" 
+		   th:object="${wordForm}">
 
 		<input type="hidden" th:field="*{id}" />
 		<input type="hidden" th:field="*{wordName}">
@@ -49,12 +52,15 @@
 
 		<button type="submit">編集する</button>
 	</form>
-	<form th:action="@{/words/{id}/editForm(id=${word.id})}" th:object="${wordForm}" style="display:inline;">
+	<form th:action="@{/wordbooks/{wordbookId}/wordList/{wordId}/editForm(wordbookId=${wordbookId},wordId=${word.id})}" 
+		  method="post"	  
+		  th:object="${wordForm}" 
+		  style="display:inline;">
+		<input type="hidden" th:field="*{id}">
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">
 		<input type="hidden" th:field="*{relatedWordIds}">
-		<input type="hidden" th:field="*{categoryName}">
 		<input th:if="${fromRegist}" type="hidden" name="fromRegist" value="${fromRegist}">
 		<button  id="return"  type="submit">入力画面に戻る</button>
 	</form>

--- a/KnowledgeMap/src/main/resources/templates/edit_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_confirm.html
@@ -24,6 +24,7 @@
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{categoryId}">
 		<input type="hidden" th:field="*{content}">
+		<input type="hidden" th:field="*{wordbookId}">
 		<input type="hidden" th:field="*{relatedWordIds}">
 
 		<div class="row">

--- a/KnowledgeMap/src/main/resources/templates/edit_error.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_error.html
@@ -7,6 +7,6 @@
 <body>
     <h1>編集エラー</h1>
     <p>指定されたWordが見つかりませんでした。</p>
-    <a th:href="@{/wordList}">一覧に戻る</a>
+    <a th:href="@{/wordbooks/{wordbookId}/wordList(wordbookId=${wordbookId})}">一覧に戻る</a>
 </body>
 </html>

--- a/KnowledgeMap/src/main/resources/templates/edit_form.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_form.html
@@ -24,6 +24,7 @@
 		  method="post" 
 		  th:object="${wordForm}">
 		<input type="hidden" th:field="*{id}" />
+		<input type="hidden" th:field="*{wordbookId}" />
 		<div class="row">
 			<label for="wordName">単語</label>
 			<div class="inputContainer">

--- a/KnowledgeMap/src/main/resources/templates/edit_form.html
+++ b/KnowledgeMap/src/main/resources/templates/edit_form.html
@@ -19,7 +19,10 @@
 <body>
 	<h1>編集</h1>
 	<p th:if="${word_duplicate} != null" th:text="${word_duplicate}"></p>
-	<form class="commonForm" th:action="@{/words/{id}/editConfirm(id=${word.id})}" method="post" th:object="${wordForm}">
+	<form th:action="@{/wordbooks/{wordbookId}/wordList/{wordId}/editConfirm(wordbookId=${wordbookId},wordId=${word.id})}" 
+		  class="commonForm" 
+		  method="post" 
+		  th:object="${wordForm}">
 		<input type="hidden" th:field="*{id}" />
 		<div class="row">
 			<label for="wordName">単語</label>
@@ -41,7 +44,7 @@
 				<div th:if="${existingWord != null}" class="existingWordDetail" th:object="${existingWord}">
 					<div class="wordNameContainer">
 						<div class="wordName" th:text="*{wordName}"></div>
-						<a th:href="@{/words/{id}/editForm(id=${existingWord.id},fromRegist='fromRegist')}"
+						<a th:href="@{/wordbooks/{wordbookId}/wordList/{wordId}/editForm(worddbookId={wordbookId},wordId=${existingWord.id},fromRegist='fromRegist')}"
 							class="button editBtn">
 							<span class="bi bi-pencil-fill"></span>
 						</a>
@@ -112,7 +115,7 @@
 		<button type="submit">入力内容の確認</button>
 	</form>
 	<!-- 新規登録からの遷移の場合、戻るボタンは 登録画面へ -->
-	<form th:if="${fromRegist}" th:action="@{/registConfirm}" method="post" th:object="${wordForm}">
+	<form th:if="${fromRegist}" th:action="@{/wordbooks/{wordbookId}/wordList/registConfirm(wordbookId=${wordbookId})}" method="post" th:object="${wordForm}">
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">
@@ -120,7 +123,7 @@
 		<button id="return">登録確認に戻る</button>
 	</form>
 	<!-- 編集からの遷移の場合、戻るボタンはword一覧へ-->
-	<form th:unless="${fromRegist}" th:action="@{/wordList}">
+	<form th:unless="${fromRegist}" th:action="@{/wordbooks/{wordbookId}/wordList(wordbookId=${wordbookId})}">
 		<input type="hidden" th:field="${wordForm.categoryId}">
 		<input type="hidden" th:field="${word.id}">
 		<button id="return">単語一覧へ戻る </button>

--- a/KnowledgeMap/src/main/resources/templates/login.html
+++ b/KnowledgeMap/src/main/resources/templates/login.html
@@ -1,15 +1,23 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
 <head>
-<meta charset="UTF-8">
-<title>ログイン</title>
+	<meta charset="UTF-8">
+	<title>ログイン</title>
+	<link rel="stylesheet" th:href="@{/css/common.css}">
+	<link rel="stylesheet" th:href="@{/css/login.css}">
+
 </head>
+
 <body>
 	<h1>ログイン</h1>
-	<form th:action="@{/login}" method="post">
-		<label>username：<input type="text" name="username"></label>
-		<label>password：<input type="password" name="password"></label>	
+	<form class="commonForm" th:action="@{/login}" method="post">
+		<div class="inputContainer">
+			<label>ユーザ名：<input type="text" name="username"></label>
+			<label>パスワード：<input type="password" name="password"></label>
+		</div>
 		<button type="submit">ログイン</button>
 	</form>
 </body>
-</html>
+
+</html>.

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -20,6 +20,7 @@
 				<input type="hidden" th:field="*{wordName}">
 				<input type="hidden" th:field="*{categoryId}">
 				<input type="hidden" th:field="*{content}">
+				<input type="hidden" th:field="*{wordbookId}">
 				<input type="hidden" th:field="*{relatedWordIds}">
 		
 		<div class="row">

--- a/KnowledgeMap/src/main/resources/templates/regist_confirm.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_confirm.html
@@ -14,7 +14,7 @@
 
 <body>
 	<h1>登録確認</h1>
-	<form class="commonForm" th:action="@{/regist}" method="post" th:object="${wordForm}">
+	<form class="commonForm" th:action="@{/wordbooks/{wordbookId}/wordList/regist(wordbookId=${wordbookId})}" method="post" th:object="${wordForm}">
 	<h4>以下の内容で登録します。</h4>
 		
 				<input type="hidden" th:field="*{wordName}">
@@ -48,7 +48,7 @@
 
 		<button type="submit">登録する</button>
 	</form>
-	<form th:action="@{/showWordForm}" method="post" th:object="${wordForm}">
+	<form th:action="@{/wordbooks/{wordbookId}/wordList/showWordForm(wordbookId=${wordbookId})}" method="post" th:object="${wordForm}">
 		<input type="hidden" th:field="*{wordName}">
 		<input type="hidden" th:field="*{content}">
 		<input type="hidden" th:field="*{categoryId}">

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -21,6 +21,7 @@
 	<h1>新規登録</h1>
 	<form class="commonForm" th:action="@{/wordbooks/{wordbookId}/wordList/registConfirm(wordbookId=${wordbookId})}" method="post" th:object="${wordForm}">
 		<input type="hidden" th:field="*{id}">
+		<input type="hidden" th:field="*{wordbookId}">
 
 		<div class="row">
 			<label for="wordName">単語</label>

--- a/KnowledgeMap/src/main/resources/templates/regist_form.html
+++ b/KnowledgeMap/src/main/resources/templates/regist_form.html
@@ -19,7 +19,7 @@
 
 <body>
 	<h1>新規登録</h1>
-	<form class="commonForm" th:action="@{/registConfirm}" method="post" th:object="${wordForm}">
+	<form class="commonForm" th:action="@{/wordbooks/{wordbookId}/wordList/registConfirm(wordbookId=${wordbookId})}" method="post" th:object="${wordForm}">
 		<input type="hidden" th:field="*{id}">
 
 		<div class="row">
@@ -116,7 +116,7 @@
 
 	</form>
 
-	<a id="return" class="button" th:href="@{/wordList}">一覧へ戻る</a>
+	<a id="return" class="button" th:href="@{/wordbooks/{wordbookId}/wordList(wordbookId=${wordbookId})}">一覧へ戻る</a>
 
 </body>
 

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -14,7 +14,7 @@
 	<h1>単語帳</h1>
 
 	<div id="regist">
-		<a th:href="@{/showWordForm}" class="button"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
+		<a th:href="@{/wordbooks/{wordbookId}/wordList/showWordForm(wordbookId=${wordbookId})}" class="button"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
 	</div>
 
 	<div class="mainContainer">
@@ -40,7 +40,7 @@
 		<!-- wordDetail -->
 		<div id="wordDetailOuter">
 			<h4>Detail</h4>
-			<div class="wordDetailContainer">
+			<div class="wordDetailContainer" th:attr="data-wordbook-id=${wordbookId}">
 				<div class="message" th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
 				<div class="message" th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
 			</div>

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -14,7 +14,7 @@
 	<h1>単語帳</h1>
 
 	<div id="regist">
-		<a th:href="@{/wordbooks/{wordbookId}/wordList/showWordForm(wordbookId=${wordbookId})}" class="button"><span class="bi bi-plus-circle-fill"></span>単語を追加</a>
+		<a th:href="@{/wordbooks/{wordbookId}/wordList/showWordForm(wordbookId=${wordbookId})}" class="button"><span class="bi bi-plus-circle-fill"></span>&nbsp;単語を追加</a>
 	</div>
 
 	<div class="mainContainer">
@@ -45,6 +45,10 @@
 				<div class="message" th:if="${edit_ok} != null" th:text="${edit_ok}"></div>
 			</div>
 		</div>
+	</div>
+	
+	<a th:href="@{/wordbooks}" id="return" class="button">単語帳一覧へ戻る</a>
+
 		<!-- 削除確認モーダル -->
 		<div id="deleteConfirmModal" class="modalHidden">
 			<p>本当に削除しますか？</p>

--- a/KnowledgeMap/src/main/resources/templates/wordbook_list.html
+++ b/KnowledgeMap/src/main/resources/templates/wordbook_list.html
@@ -4,15 +4,17 @@
 <head>
 <meta charset="UTF-8">
 <title>単語帳一覧</title>
+<link rel="stylesheet" th:href="@{/css/common.css}">
+<link rel="stylesheet" th:href="@{/css/wordbook_list.css}">
 </head>
 <body>
 	<h1>ホーム</h1>
-	<p>ようこそ、<span sec:authentication="principal.username">username</span>さん</p>
-	<ul>
+	<h3><span sec:authentication="principal.username">username</span>さんの単語帳一覧</h3>
+	<ul class="wordbookList">
 		<li th:each="wordbook : ${wordbookList}">
 			<a th:href="@{/wordbooks/{wordbookId}/wordList(wordbookId=${wordbook.id})}" th:text="${wordbook.name}"></a>
 		</li>
 	</ul>
-
+	<a th:href="@{/login}" id="return" class="button">ログアウトする</a>
 </body>
 </html>

--- a/KnowledgeMap/src/main/resources/templates/wordbook_list.html
+++ b/KnowledgeMap/src/main/resources/templates/wordbook_list.html
@@ -3,14 +3,14 @@
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
 <meta charset="UTF-8">
-<title>ホーム</title>
+<title>単語帳一覧</title>
 </head>
 <body>
 	<h1>ホーム</h1>
 	<p>ようこそ、<span sec:authentication="principal.username">username</span>さん</p>
 	<ul>
 		<li th:each="wordbook : ${wordbookList}">
-			<a th:href="@{/wordbooks/{id}/words}" th:text="${wordbook.name}"></a>
+			<a th:href="@{/wordbooks/{wordbookId}/wordList(wordbookId=${wordbook.id})}" th:text="${wordbook.name}"></a>
 		</li>
 	</ul>
 


### PR DESCRIPTION
### URL設計の見直し
URLを以下のように変更し、
どの単語帳に属する単語への操作なのかわかるようにしました。

/wordbooks/{wordbookId}/wordList/{wordId}/ edit~
/wordbooks/{wordbookId}/wordList/{wordId}/ regist~


### wordbookIdフィールドの導入
カテゴリや単語が属している単語帳を判別するため単語帳Idのカラムを追加。
Category と Word エンティティに、Wordbook を紐づけることで、
関連語セレクトボックス用のWord一覧取得や
カテゴリセレクトボックスの一覧取得の際に
**現在利用中の単語帳に属するもの**のみを返すように変更しました
