### PR TITLE
Feature/#88 delete msg

### DIFF
--- a/KnowledgeMap/src/main/java/com/example/demo/controller/WordbookApiController.java
+++ b/KnowledgeMap/src/main/java/com/example/demo/controller/WordbookApiController.java
@@ -1,8 +1,10 @@
 package com.example.demo.controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
@@ -59,12 +61,13 @@ public class WordbookApiController {
 		return ResponseEntity.ok(dto);
 	}
 	@DeleteMapping("/delete/{id}")
-	public ResponseEntity<Void> delete(@PathVariable("id") Integer id){
+	public ResponseEntity<?> delete(@PathVariable("id") Integer id){
 		boolean deleted = wordbookService.deleteById(id);
 		if (deleted){
 			return ResponseEntity.ok().build();
 		}
-		return ResponseEntity.notFound().build();
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+				.body(Map.of("error","指定された単語張は存在しません"));
 	}
 
 }

--- a/KnowledgeMap/src/main/resources/static/css/common.css
+++ b/KnowledgeMap/src/main/resources/static/css/common.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+
 :root {
 	--main-bg-color: #f4f4fa;
 	--main-text-color: #201f30;
@@ -6,62 +7,71 @@
 	--hover-bg-color: #353e60;
 	--line-color: #b0aec8;
 }
+
 * {
 	box-sizing: border-box;
 	margin: 0;
 	padding: 0;
 }
+
 body {
 	display: flex;
 	flex-direction: column;
-	align-items: center;	
+	align-items: center;
 	background-color: var(--main-bg-color);
 	color: var(--main-text-color);
 }
-h1{
+
+h1 {
 	font-size: 2rem;
-	padding:2rem;
+	padding: 2rem;
 }
-ul{
+
+ul {
 	list-style: none;
 }
+
 /* ボタン */
 button,
 .button {
-	background-color:  var(--main-text-color);
+	background-color: var(--main-text-color);
 	color: var(--container-bg-color);
-	border: 1px solid var(--main-text-color);		
+	border: 1px solid var(--main-text-color);
 	border-radius: 5px;
 	text-decoration: none;
-	text-align: center;	
+	text-align: center;
 	cursor: pointer;
 }
+
 button:hover,
-.button:hover{
+.button:hover {
 	background-color: var(--hover-bg-color)
 }
+
 /* フォーム内ボタン */
-.commonForm button{
+.commonForm button {
 	display: block;
 	width: 30%;
-	margin:  0 auto;
+	margin: 0 auto;
 	padding: 0.6rem 1.5rem;
 	font-size: 0.8rem;
 }
+
 /* 戻るボタン */
-#return{
-	display:block;		
+#return {
+	display: block;
 	width: 10rem;
-	margin:2rem;
-	padding: 0.6rem 1.5rem;		
+	margin: 2rem;
+	padding: 0.6rem 1.5rem;
 	font-size: 0.8rem;
 	background-color: var(--container-bg-color);
 	color: var(--main-text-color);
-	border:1px solid var(--main-text-color);
+	border: 1px solid var(--main-text-color);
 }
-#return:hover{
+
+#return:hover {
 	background-color: var(--hover-bg-color);
-	color:var(--container-bg-color);
+	color: var(--container-bg-color);
 	border: 1px solid var(--container-bg-color);
 }
 
@@ -76,16 +86,19 @@ button:hover,
 	background-color: var(--container-bg-color);
 	cursor: pointer;
 }
-.deleteBtn span{
+
+.deleteBtn span {
 	color: #777499;
 	font-size: 1rem;
 }
- .deleteBtn:hover{
+
+.deleteBtn:hover {
 	background-color: #e5e5ee;
 	color: var(--main-text-color);
 }
+
 /* フォーム */
-.commonForm{
+.commonForm {
 	width: 80%;
 	max-width: 800px;
 	min-width: 500px;
@@ -94,71 +107,85 @@ button:hover,
 	border-radius: 10px;
 	padding: 2rem;
 }
+
 /* フォームの1行分 */
-.row{
-	display:grid;
+.row {
+	display: grid;
 	grid-template-columns: 15% 1fr;
 	padding: 0.2rem 0;
 	align-items: start;
 	column-gap: 2rem;
 }
+
 /* フォームの右側 */
-.row label{
+.row label {
 	font-weight: bold;
 	font-size: 1rem;
 	color: var(--main-text-color);
 	text-align: right;
 }
+
 /* フォームの左側 */
-.inputContainer{
-	padding:0 0.3rem;
-	width:100%;
-	min-height: 2.5rem; 
+.inputContainer {
+	padding: 0 0.3rem;
+	width: 100%;
+	min-height: 2.5rem;
 }
+
 /* 削除確認モーダル */
- :root{
- 	--modal-top:50%;
- 	--modal-left:50%;
- }
-.hidden{
-	display:none;
+:root {
+	--modal-top: 50%;
+	--modal-right: 50%;
+	--modal-width: 0;
 }
-#modalOuter{	
+
+.hidden {
+	display: none;
+}
+
+#modalOuter {
+	font-size: 0.9rem;
 	position: absolute;
 	top: var(--modal-top);
-	left: var(--modal-left);
-	
-	width: 15rem;
-	padding:1.5rem;
-	text-align: center;	
-	
+	right: var(--modal-right);
+
+	width: var(--modal-width);
+	max-width: 20%;
+	text-align: center;
+
 	background-color: #f5dede;
 	color: var(--main-text-color);
 	border: 2px solid var(--main-text-color);
 	border-radius: 10px;
-	
+
 	z-index: 1000;
+}
+
+#modalOuter p {
+	margin: 0.5rem;
 }
 
 #modalOverlay {
 	position: fixed;
 	top: 0;
 	left: 0;
-	
+
 	width: 100vw;
 	height: 100vh;
-	
+
 	background-color: rgba(0, 0, 0, 0.3);
-	
+
 	z-index: 999;
 }
-#modalOuter button{
-	margin: 0.5rem 1rem;
-	padding:0.5rem;
+
+#modalOuter button {
+	font-size: 0.8rem;
+	margin: 0.1rem 0.1rem;
+	padding: 0.5rem;
 }
 
-
-
-
-
-
+#btnContainer {
+	display: flex;
+	justify-content: space-evenly;
+	margin-bottom: 0.5rem;
+}

--- a/KnowledgeMap/src/main/resources/static/css/common.css
+++ b/KnowledgeMap/src/main/resources/static/css/common.css
@@ -120,15 +120,15 @@ button:hover,
  	--modal-top:50%;
  	--modal-left:50%;
  }
-.modalHidden,
-.modalOverlayHidden{
+.hidden{
 	display:none;
 }
-#deleteConfirmModal{	
+#modalOuter{	
 	position: absolute;
 	top: var(--modal-top);
 	left: var(--modal-left);
 	
+	width: 15rem;
 	padding:1.5rem;
 	text-align: center;	
 	
@@ -139,6 +139,7 @@ button:hover,
 	
 	z-index: 1000;
 }
+
 #modalOverlay {
 	position: fixed;
 	top: 0;
@@ -151,7 +152,7 @@ button:hover,
 	
 	z-index: 999;
 }
-#deleteConfirmModal button{
+#modalOuter button{
 	margin: 0.5rem 1rem;
 	padding:0.5rem;
 }

--- a/KnowledgeMap/src/main/resources/static/js/modal.js
+++ b/KnowledgeMap/src/main/resources/static/js/modal.js
@@ -15,32 +15,35 @@ let deleteNgFunc = null;
 
 /**
  * モーダルを表示する共通関数
- * @param {Event} event - イベントオブジェクト
  * @param {HTMLElement} triggerEl - 削除ボタン
  * @param {Function} func - 真偽値を引数として受け取りtrueの場合はサーバへ削除リクエストを送信する関数
  * @param {Object} [options] - オプション設定
  */
 
 export function showModal({ triggerEl, func, options = {} }) {
-	modalOuter.classList.remove("hidden");
 	modalOverlay.classList.remove("hidden");
+	modalOuter.classList.remove("hidden");
+	deleteConfirmModal.classList.remove("hidden");
+	deletedMsgModal.classList.add("hidden");
 
 	// モーダルの表示位置を設定
-	const rect = triggerEl.getBoundingClientRect();
-	const modalTop = rect.bottom + scrollY + 8;
-	const modalLeft = rect.right - modalOuter.offsetWidth;
+	const outer = triggerEl.closest(".outer");
+	const outerRect = outer.getBoundingClientRect();
+	
+	const btnRect = triggerEl.getBoundingClientRect()
+	
+	const modalTop = btnRect.bottom + scrollY + 8;
+	const modalRight = window.innerWidth - outerRect.right;
+	const modalWidth = outerRect.width;
+	
 	//CSS変数に値をセット
 	document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
-	document.documentElement.style.setProperty('--modal-left', `${modalLeft}px`);
-	
-	console.log(options.selectedTargerSelecrtor);
+	document.documentElement.style.setProperty('--modal-right', `${modalRight}px`);
+	document.documentElement.style.setProperty('--modal-width', `${modalWidth}px`);
+
 	// wordbook_listにて対象となる li > a 要素を、選択中として色変更
 	if (options.selectedTargetSelector) {
-		const selectedEl = triggerEl.closest("li").querySelector(options.selectedTargetSelector);
-		console.log(selectedEl);
-		if (selectedEl) {
-			selectedEl.classList.add("selected");
-		}
+		triggerEl.closest("li").querySelector(options.selectedTargetSelector)?.classList.add("selected");
 	}
 
 	// OKボタンクリック -> func(true)を実行してモーダルを閉じる
@@ -86,9 +89,11 @@ export function closeModal() {
 	if (!modalOuter.classList.contains("hidden")) {
 		modalOuter.classList.add("hidden");
 		modalOverlay.classList.add("hidden");
-			
-		const selectedEl = document.querySelector(".selected")
-		if(selectedEl){
+		deletedMsgModal.classList.add("hidden");
+		
+
+		const selectedEl = document.querySelector(".selected");		
+		if (selectedEl) {
 			selectedEl.classList.remove("selected");
 		}
 

--- a/KnowledgeMap/src/main/resources/static/js/modal.js
+++ b/KnowledgeMap/src/main/resources/static/js/modal.js
@@ -1,0 +1,110 @@
+//削除確認モーダル
+const modalOverlay = document.getElementById("modalOverlay");
+const modalOuter = document.getElementById("modalOuter");
+const deleteConfirmModal = document.getElementById("deleteConfirmModal");
+const deletedMsgModal = document.getElementById("deletedMsgModal");
+//削除確認モーダル内のボタン
+const deleteOkBtn = document.getElementById("deleteOk");
+const deleteNgBtn = document.getElementById("deleteNg");
+//モーダル外側をクリックしたときに発生するイベントハンドラ(モーダルを閉じる処理を行う)
+let eventHandler = null;
+//モーダルの はい/いいえ ボタンをクリックしたときに発生するイベントハンドラ(削除実行を行う関数にtrue/falseを渡す)
+let deleteOkFunc = null;
+let deleteNgFunc = null;
+
+
+/**
+ * モーダルを表示する共通関数
+ * @param {Event} event - イベントオブジェクト
+ * @param {HTMLElement} triggerEl - 削除ボタン
+ * @param {Function} func - 真偽値を引数として受け取りtrueの場合はサーバへ削除リクエストを送信する関数
+ * @param {Object} [options] - オプション設定
+ */
+
+export function showModal({ triggerEl, func, options = {} }) {
+	modalOuter.classList.remove("hidden");
+	modalOverlay.classList.remove("hidden");
+
+	// モーダルの表示位置を設定
+	const rect = triggerEl.getBoundingClientRect();
+	const modalTop = rect.bottom + scrollY + 8;
+	const modalLeft = rect.right - modalOuter.offsetWidth;
+	//CSS変数に値をセット
+	document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
+	document.documentElement.style.setProperty('--modal-left', `${modalLeft}px`);
+	
+	console.log(options.selectedTargerSelecrtor);
+	// wordbook_listにて対象となる li > a 要素を、選択中として色変更
+	if (options.selectedTargetSelector) {
+		const selectedEl = triggerEl.closest("li").querySelector(options.selectedTargetSelector);
+		console.log(selectedEl);
+		if (selectedEl) {
+			selectedEl.classList.add("selected");
+		}
+	}
+
+	// OKボタンクリック -> func(true)を実行してモーダルを閉じる
+	deleteOkFunc = (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		func(true);
+	}
+	deleteOk.addEventListener("click", deleteOkFunc);
+
+	// NGボタンクリック -> func(false)を実行してモーダルを閉じる
+	deleteNgFunc = (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		func(false);
+		closeModal();
+	}
+	deleteNg.addEventListener("click", deleteNgFunc);
+
+	//モーダルの外側をクリックするとモーダルを閉じる関数
+	eventHandler = (e) => {
+		if (!modalOuter.contains(e.target)) {
+			closeModal();
+		}
+	}
+	//モーダルを閉じる関数をクリックイベントに登録
+	document.addEventListener("click", eventHandler);
+}
+// 削除完了メッセージを表示する
+export function showDeletedMsg(modalMsg) {
+	if (!deleteConfirmModal.classList.contains("hidden")) {
+		deleteConfirmModal.classList.add("hidden");
+	}
+	if (deletedMsgModal.classList.contains("hidden")) {
+		deletedMsgModal.classList.remove("hidden");
+	}
+	document.getElementById("deletedMsg").textContent = modalMsg;
+	document.getElementById("closeModalBtn").addEventListener("click", closeModal);
+}
+
+// 削除確認モーダルを閉じる
+export function closeModal() {
+	if (!modalOuter.classList.contains("hidden")) {
+		modalOuter.classList.add("hidden");
+		modalOverlay.classList.add("hidden");
+			
+		const selectedEl = document.querySelector(".selected")
+		if(selectedEl){
+			selectedEl.classList.remove("selected");
+		}
+
+		//画面全体のクリックイベント削除
+		if (eventHandler) {
+			document.removeEventListener("click", eventHandler);
+			eventHandler = null;
+		}
+		//はい/いいえボタンのクリックイベント削除
+		if (deleteOkFunc) {
+			deleteOk.removeEventListener("click", deleteOkFunc);
+			deleteOkFunc = null;
+		}
+		if (deleteNgFunc) {
+			deleteNg.removeEventListener("click", deleteNgFunc);
+			deleteNgFunc = null;
+		}
+	}
+}

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -67,9 +67,8 @@ function setCategorySelection(categoryId) {
 // 選択中の単語の色変更
 function setWordSelection(wordId) {
 	const wordBtns = document.querySelectorAll(".wordBtn");
-	console.log([...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") == wordId));
-	[...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") == wordId)
-		.classList.add("wordBtnSelected");
+	[...wordBtns].find(wordBtn => wordBtn.getAttribute("data-id") == wordId)?.classList.add("wordBtnSelected");
+
 }
 //category削除
 async function deleteCategory(event, categoryId) {

--- a/KnowledgeMap/src/main/resources/static/js/word_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/word_list.js
@@ -1,4 +1,4 @@
-
+import { showModal, showDeletedMsg, closeModal } from "./modal.js";
 // 各コンテナ
 const mainConteiner = document.querySelector(".mainContainer");
 const categoryContainer = document.querySelector(".categoryContainer");
@@ -15,22 +15,13 @@ const wordbookId = wordDetailContainer.dataset.wordbookId;
 //CSRFトークンの取得
 const csrfToken = document.getElementById("csrfToken").value;
 
-
-//削除確認モーダル
-const deleteConfirmModal = document.getElementById("deleteConfirmModal");
-const deleteOkBtn = document.getElementById("deleteOk");
-const deleteNgBtn = document.getElementById("deleteNg");
-//モーダル外側をクリックしたときに発生するイベントハンドラ(モーダルを閉じる処理を行う)
-let eventHandler = null;
-//モーダルの はい/いいえ ボタンをクリックしたときに発生するイベントハンドラ()
-let deleteOkFunc = null;
-let deleteNgFunc = null;
-
+// 削除実行後にモーダルに表示する処理結果メッセージ
+let modalMsg;
 
 /*
-更新処理を実行後、リダイレクトで一覧画面に戻ると
-処理対象の単語が表示された状態にする
-(カテゴリ一覧と単語一覧から該当する対象が選択され、かつwordDetailが表示された状態)
+	更新処理を実行後、リダイレクトで一覧画面に戻ると
+	処理対象の単語が表示された状態にする
+	(カテゴリ一覧と単語一覧から該当する対象が選択され、かつwordDetailが表示された状態)
 */
 window.addEventListener("DOMContentLoaded", async () => {
 	const params = new URLSearchParams(window.location.search);
@@ -83,25 +74,35 @@ function setWordSelection(wordId) {
 //category削除
 async function deleteCategory(event, categoryId) {
 	event.stopPropagation();
-	showModal(event, async () => {
-		try {
-			const res = await fetch(
-				`/api/categories/${categoryId}`,
-				{
-					method: "DELETE",
-					headers: { "X-CSRF-TOKEN": csrfToken }
-				});
-			if (res.ok) {
-				event.target.closest("li").remove();
-			} else {
-				const errorMsg = await res.json();
-				alert(errorMsg.error || "削除に失敗しました");
-			}
-		} catch (error) {
-			console.error(error);
-			alert("通信エラーが発生しました");
-		}
-	})
+	showModal(
+		{
+			triggerEl: event.currentTarget,
+			func:
+				async (isConfirmed) => {
+					if(!isConfirmed){
+						return;
+					}
+					try {
+						const res = await fetch(
+							`/api/categories/${categoryId}`,
+							{
+								method: "DELETE",
+								headers: { "X-CSRF-TOKEN": csrfToken }
+							});
+						if (res.ok) {
+							event.target.closest("li").remove();
+							modalMsg = "削除しました";
+						} else {
+							const errorMsg = await res.json();
+							modalMsg = errorMsg.error
+						}
+					} catch (error) {
+						console.error(error);
+						modalMsg = "削除に失敗しました";
+					}
+					showDeletedMsg(modalMsg);
+				}
+		})
 }
 // 単語一覧を表示
 async function showWordList(categoryId) {
@@ -123,7 +124,9 @@ async function showWordList(categoryId) {
 				categoryDeleteBtn.appendChild(span);
 				//カテゴリボタンの横にカテゴリ削除ボタンを追加
 				[...categoryBtns].find(btn => btn.getAttribute("data-id") === categoryId).after(categoryDeleteBtn);
-				categoryDeleteBtn.addEventListener("click", (event) => deleteCategory(event, categoryId))
+
+				const li =
+					categoryDeleteBtn.addEventListener("click", (event) => deleteCategory(event, categoryId))
 
 				// 単語ありの場合
 			} else {
@@ -251,93 +254,37 @@ async function showWordDetail(wordId) {
 }
 
 //word削除
-async function deleteWord(event, wordId, li) {
+async function deleteWord(event, wordId) {
 	event.stopPropagation();
-	showModal(event, async (isConfirmed) => {
-		if (!isConfirmed) {
-			return;
-		}
-		try {
-			const res = await fetch(
-				`/api/words/${wordId}`,
-				{
-					method: "DELETE",
-					headers: { "X-CSRF-TOKEN": csrfToken }
-				});
-			if (res.ok) {
-				li.remove();
-				wordDetailContainer.innerHTML = "";
-				document.querySelector(".deleteMsg").textContent = "削除しました";
-			} else if (res.status === 404) {
-				const errorMsg = await res.json();
-				alert(errorMsg.error || "削除に失敗しました");
-			}
-		} catch (error) {
-			console.log(error);
-			alert("通信エラーが発生しました");
-		}
-	})
-}
-
-// モーダルを表示する関数
-// 引数として受け取る関数funcは、 「引数がtrueの時に削除実行のリクエストを送る」関数
-function showModal(event, func) {
-	deleteConfirmModal.classList.remove("modalHidden");
-	modalOverlay.classList.remove("modalOverlayHidden");
-
-	// モーダルの表示位置を設定
-	const rect = event.currentTarget.getBoundingClientRect();
-	const modalTop = rect.bottom + scrollY + 8;
-	const modalLeft = rect.right - deleteConfirmModal.offsetWidth;
-	//CSS変数に値をセット
-	document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
-	document.documentElement.style.setProperty('--modal-left', `${modalLeft}px`);
-
-	// OKボタンクリック -> func(true)を実行してモーダルを閉じる
-	deleteOkFunc = (event) => {
-		event.preventDefault();
-		event.stopPropagation();
-		func(true);
-		closeModal();
-	}
-	deleteOk.addEventListener("click", deleteOkFunc);
-	// NGボタンクリック -> func(false)を実行してモーダルを閉じる
-	deleteNgFunc = (event) => {
-		event.preventDefault();
-		event.stopPropagation();
-		func(false);
-		closeModal();
-	}
-	deleteOk.addEventListener("click", deleteOkFunc);
-	
-	//モーダルの外側をクリックするとモーダルを閉じる関数
-	eventHandler = (event) => {
-		if (!deleteConfirmModal.contains(event.target)) {
-			closeModal();
-		}
-	}
-	//モーダルを閉じる関数をクリックイベントに登録
-	document.addEventListener("click", eventHandler);
-}
-// 削除確認モーダルを閉じる
-function closeModal() {
-	if (!deleteConfirmModal.classList.contains("modalHidden")) {
-		deleteConfirmModal.classList.add("modalHidden");
-		modalOverlay.classList.add("modalOverlayHidden");
-		
-		//画面全体のクリックイベント削除
-		if (eventHandler) {
-			document.removeEventListener("click", eventHandler);
-			eventHandler = null;
-		}
-		//はい/いいえボタンのクリックイベント削除
-		if (deleteOkFunc) {
-			deleteOk.removeEventListener("click", deleteOkFunc);
-			deleteOkFunc = null;
-		}
-		if (deleteNgFunc) {
-			deleteNg.removeEventListener("click", deleteNgFunc);
-			deleteNgFunc = null;
-		}
-	}
+	showModal(
+		{
+			triggerEl: event.currentTarget,
+			func:
+				async (isConfirmed) => {
+					if (!isConfirmed) {
+						return;
+					}
+					try {
+						const res = await fetch(
+							`/api/words/${wordId}`,
+							{
+								method: "DELETE",
+								headers: { "X-CSRF-TOKEN": csrfToken }
+							});
+						if (res.ok) {
+							event.target.closest("li").remove();
+							wordDetailContainer.innerHTML = "";
+							modalMsg = "削除しました";
+						} else if (res.status === 404) {
+							const errorMsg = await res.json();
+							modalMsg = errorMsg.error;
+						}
+					} catch (error) {
+						console.log(error);
+						modalMsg = "削除に失敗しました";
+					}
+					// 削除結果のメッセージ表示
+					showDeletedMsg(modalMsg);
+				}
+		})
 }

--- a/KnowledgeMap/src/main/resources/static/js/wordbook_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/wordbook_list.js
@@ -8,18 +8,6 @@ const showFormBtn = document.getElementById("showFormBtn");
 //バリデーションエラー表示
 const errorMsgList = document.getElementById("errorMsgList");
 
-//削除確認モーダル
-const modalOverlay = document.getElementById("modalOverlay");
-const modalOuter = document.getElementById("modalOuter");
-const deleteConfirmModal = document.getElementById("deleteConfirmModal");
-//削除確認モーダル内のボタン
-const deleteOk = document.getElementById("deleteOk");
-const deleteNg = document.getElementById("deleteNg");
-//モーダル外側をクリックしたときに発生するイベントハンドラ(モーダルを閉じる処理を行う)
-let eventHandler = null;
-//モーダルの はい/いいえ ボタンをクリックしたときに発生するイベントハンドラ(削除実行を行う関数にtrue/falseを渡す)
-let deleteOkFunc = null;
-let deleteNgFunc = null;
 // 削除実行後にモーダルに表示する処理結果メッセージ
 let modalMsg;
 

--- a/KnowledgeMap/src/main/resources/static/js/wordbook_list.js
+++ b/KnowledgeMap/src/main/resources/static/js/wordbook_list.js
@@ -1,109 +1,122 @@
+import { showModal, showDeletedMsg, closeModal } from "./modal.js";
 
-document.addEventListener("DOMContentLoaded", () => {
-	//登録用フォーム
-	const registForm = document.querySelector(".commonForm");
-	//登録用フォームの表示/非表示切り替えボタン
-	const showFormBtn = document.getElementById("showFormBtn");
-	//バリデーションエラー表示
-	const errorMsgList = document.getElementById("errorMsgList");
-	/*
-	単語帳の登録フォーム表示
-	*/
-	showFormBtn.addEventListener("click", () => {
-		if (!registForm.classList.toggle("hidden")) {//hiddenが存在して削除したとき
-			registForm.classList.add("visible");
+
+//登録用フォーム
+const registForm = document.querySelector(".commonForm");
+//登録用フォームの表示/非表示切り替えボタン
+const showFormBtn = document.getElementById("showFormBtn");
+//バリデーションエラー表示
+const errorMsgList = document.getElementById("errorMsgList");
+
+//削除確認モーダル
+const modalOverlay = document.getElementById("modalOverlay");
+const modalOuter = document.getElementById("modalOuter");
+const deleteConfirmModal = document.getElementById("deleteConfirmModal");
+//削除確認モーダル内のボタン
+const deleteOk = document.getElementById("deleteOk");
+const deleteNg = document.getElementById("deleteNg");
+//モーダル外側をクリックしたときに発生するイベントハンドラ(モーダルを閉じる処理を行う)
+let eventHandler = null;
+//モーダルの はい/いいえ ボタンをクリックしたときに発生するイベントハンドラ(削除実行を行う関数にtrue/falseを渡す)
+let deleteOkFunc = null;
+let deleteNgFunc = null;
+// 削除実行後にモーダルに表示する処理結果メッセージ
+let modalMsg;
+
+
+/*
+単語帳の登録フォーム表示
+*/
+showFormBtn.addEventListener("click", () => {
+	if (!registForm.classList.toggle("hidden")) {//hiddenが存在して削除したとき
+		registForm.classList.add("visible");
+	} else {
+		registForm.classList.remove("visible");//hiddenが存在せず追加したとき	
+	}
+})
+/*
+単語帳の登録処理実行
+*/
+registForm.addEventListener("submit", async (event) => {
+	event.preventDefault();
+	errorMsgList.innerHTML = "";
+	const wordbookName = document.getElementById("wordbookName").value.trim();
+	const userId = document.getElementById("userId").value;
+	const csrfToken = document.getElementById("csrfToken").value;
+	try {
+		const res = await fetch(`/wordbooks/api/regist`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				"X-CSRF-TOKEN": csrfToken
+			},
+			body: `wordbookName=${encodeURIComponent(wordbookName)}&userId=${userId}`
+		});
+		if (res.ok) {
+			const wordbook = await res.json();
+			addWordbookToList(wordbook.id, wordbook.wordbookName);
 		} else {
-			registForm.classList.remove("visible");//hiddenが存在せず追加したとき	
-		}
-	})
-	/*
-	単語帳の登録処理実行
-	*/
-	registForm.addEventListener("submit", async (event) => {
-		event.preventDefault();
-		errorMsgList.innerHTML = "";
-		const wordbookName = document.getElementById("wordbookName").value.trim();
-		const userId = document.getElementById("userId").value;
-		const csrfToken = document.getElementById("csrfToken").value;
-		try {
-			const res = await fetch(`/wordbooks/api/regist`, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/x-www-form-urlencoded",
-					"X-CSRF-TOKEN": csrfToken
-				},
-				body: `wordbookName=${encodeURIComponent(wordbookName)}&userId=${userId}`
-			});
-			if (res.ok) {
-				const wordbook = await res.json();
-				addWordbookToList(wordbook.id, wordbook.wordbookName);
-			} else {
-				//バリデーションエラーがあるとき
-				errorMsgList.classList.replace("errorMsgHidden", "errorMsgVisible");
-				const errorMessages = await res.json();
-				for (const msg of errorMessages) {
-					const li = document.createElement("li");
-					li.textContent = msg;
-					errorMsgList.append(li);
-				}
+			//バリデーションエラーがあるとき
+			errorMsgList.classList.replace("errorMsgHidden", "errorMsgVisible");
+			const errorMessages = await res.json();
+			for (const msg of errorMessages) {
+				const li = document.createElement("li");
+				li.textContent = msg;
+				errorMsgList.append(li);
 			}
-		} catch (error) {
-			alert("登録に失敗しました");
 		}
-	})
-	//単語帳リストにDOMを追加する関数
-	function addWordbookToList(wordbookId, wordbookName) {
-		
-		const wordbookList = document.querySelector(".wordbookList");
-		const li = document.createElement("li");
-		const a = document.createElement("a");
-		
-		a.href = `/wordbooks/${wordbookId}/words`;
-		a.textContent = wordbookName;
-		li.appendChild(a);
-		
-		const form = document.createElement("form");
-		form.className = "buttonContainer";
-		form.innerHTML = `
+	} catch (error) {
+		alert("登録に失敗しました");
+	}
+})
+//単語帳リストにDOMを追加する関数
+function addWordbookToList(wordbookId, wordbookName) {
+
+	const wordbookList = document.querySelector(".wordbookList");
+	const li = document.createElement("li");
+	const a = document.createElement("a");
+
+	a.href = `/wordbooks/${wordbookId}/words`;
+	a.textContent = wordbookName;
+	li.appendChild(a);
+
+	const form = document.createElement("form");
+	form.className = "buttonContainer";
+	form.innerHTML = `
 		<input type="hidden" id="csrfToken" value="${document.getElementById("csrfToken").value}" />
 		<button class="deleteBtn" data-id="${wordbookId}"><span class="bi-trash3-fill"></span></button>
 		`;
-		li.appendChild(form);
-		
-		wordbookList.insertBefore(li, wordbookList.firstElementChild);
+	li.appendChild(form);
 
-		document.getElementById("wordbookName").value = "";
-	}
+	wordbookList.insertBefore(li, wordbookList.firstElementChild);
 
+	document.getElementById("wordbookName").value = "";
+}
 
-	/*
-	単語帳の削除
+/*
+単語帳の削除
 	
-	(動的に追加される単語帳に対してもイベントを付与するため、親要素にイベントを登録する)
-	*/
+(動的に追加される単語帳に対してもイベントを付与するため、親要素にイベントを登録する)
+*/
 
-	const deleteConfirmModal = document.getElementById("deleteConfirmModal");
-	const modalOverlay = document.getElementById("modalOverlay");
-	const deleteOk = document.getElementById("deleteOk");
-	const deleteNg = document.getElementById("deleteNg");
-	
-	document.querySelector(".wordbookList").addEventListener("click", async (event) => {
-		const deleteBtn = event.target.closest(".deleteBtn");
-		if (!deleteBtn) return;
 
-		event.stopPropagation();
-		event.preventDefault();//documentへのイベント伝播によるcloseModal()の即実行を防ぐ
-		
-		// モーダルの表示
-		showModal(deleteBtn, async (isConfirmed) => {
+document.querySelector(".wordbookList").addEventListener("click", async (event) => {
+	const deleteBtn = event.target.closest(".deleteBtn");
+	if (!deleteBtn) return;
+
+	event.stopPropagation();
+	event.preventDefault();//documentへのイベント伝播によるcloseModal()の即実行を防ぐ
+
+	// モーダルの表示
+	showModal({
+		triggerEl: deleteBtn,
+		func: async (isConfirmed) => {
 			const id = deleteBtn.dataset.id;
 			const csrfToken = document.getElementById("csrfToken").value;
 
 			if (!isConfirmed) {
-				console.log("funcにfalseが渡った")
 				return;
 			}
-			console.log("funcにtrueが渡った")
 			try {
 				const res = await fetch(`/wordbooks/api/delete/${id}`,
 					{
@@ -112,64 +125,20 @@ document.addEventListener("DOMContentLoaded", () => {
 					});
 				if (res.ok) {
 					deleteBtn.closest('li').remove();
+					modalMsg = "削除しました";
+				} else if (res.status === 404) {
+					const errorMsg = await res.json();
+					modalMsg = errorMsg.error;
 				}
 			} catch (error) {
 				console.log(error);
+				modalMsg = "削除に失敗しました";
 			}
-		})
+			showDeletedMsg(modalMsg);
+		},
+		options: {
+			selectedTargetSelector: "a"
+		}
 	})
-
-	// モーダルを表示する関数
-	// 引数として受け取る関数funcは、 「引数がtrueの時に削除実行のリクエストを送る」関数
-	function showModal(deleteBtn, func) {
-		deleteConfirmModal.classList.remove("modalHidden");
-		modalOverlay.classList.remove("modalOverlayHidden");
-		deleteBtn.closest("li").querySelector("a").classList.add("selected");
-			
-		// モーダルの表示位置を設定
-		const rect = deleteBtn.getBoundingClientRect();
-		const modalTop = rect.bottom + scrollY + 8;
-		const modalLeft = rect.right - deleteConfirmModal.offsetWidth;
-		//CSS変数に値をセット
-		document.documentElement.style.setProperty('--modal-top', `${modalTop}px`);
-		document.documentElement.style.setProperty('--modal-left', `${modalLeft}px`);
-
-		// OKボタンクリック -> func(true)を実行してモーダルを閉じる
-		deleteOk.addEventListener("click", (event) => {
-			event.preventDefault();
-			event.stopPropagation();
-			func(true);
-			closeModal();
-		})
-
-		// NGボタンクリック -> func(false)を実行してモーダルを閉じる
-		deleteNg.addEventListener("click", (event) => {
-			event.preventDefault();
-			event.stopPropagation();
-			func(false);
-			closeModal();
-		})
-
-		//モーダルの外側をクリックするとモーダルを閉じる関数
-		eventHandler = (event) => {
-			if (!deleteConfirmModal.contains(event.target)) {
-				closeModal();
-			}
-		}
-		//モーダルを閉じる関数をクリックイベントに登録
-		document.addEventListener("click", eventHandler);
-	}
-	// モーダルを閉じる関数
-	function closeModal() {
-		console.log("closeModal実行");
-		deleteConfirmModal.classList.add("modalHidden");
-		modalOverlay.classList.add("modalOverlayHidden");
-		document.querySelector(".selected").classList.remove("selected");
-		if (eventHandler) {
-			document.removeEventListener("click", eventHandler);
-			eventHandler = null;
-		}
-	}
 })
-
 

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -6,13 +6,13 @@
 	<title>単語一覧</title>
 	<link rel="stylesheet" th:href="@{/css/word_list.css}">
 	<link rel="stylesheet" th:href="@{/css/common.css}">
-	<script th:src="@{/js/word_list.js}" defer></script>
+	<script type="module" th:src="@{/js/word_list.js}" defer></script>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 </head>
 
 <body>
 	<h1>単語帳</h1>
-	<input type="hidden" id="csrfToken" th:value="${_csrf.token}" />				
+	<input type="hidden" id="csrfToken" th:value="${_csrf.token}" />
 
 	<div id="regist">
 		<a th:href="@{/wordbooks/{wordbookId}/words/showWordForm(wordbookId=${wordbookId})}" class="button"><span
@@ -50,14 +50,20 @@
 	</div>
 
 	<a th:href="@{/wordbooks}" id="return" class="button">単語帳一覧へ戻る</a>
-	
+
 	<!-- 背景オーバーレイ -->
-	<div id="modalOverlay" class="modalOverlayHidden"></div>
+	<div id="modalOverlay" class="hidden"></div>
 	<!-- 削除確認モーダル -->
-	<div id="deleteConfirmModal" class="modalHidden">
-		<p>本当に削除しますか？</p>
-		<button id="deleteOk">はい</button>
-		<button id="deleteNg">いいえ</button>
+	<div id="modalOuter" class="hidden">
+		<div id="deleteConfirmModal" class="">
+			<p>本当に削除しますか？</p>
+			<button id="deleteOk">はい</button>
+			<button id="deleteNg">いいえ</button>
+		</div>
+		<div id="deletedMsgModal" class="hidden">
+			<p id="deletedMsg"></p>
+			<button id="closeModalBtn">閉じる</button>		
+		</div>
 	</div>
 </body>
 

--- a/KnowledgeMap/src/main/resources/templates/word_list.html
+++ b/KnowledgeMap/src/main/resources/templates/word_list.html
@@ -21,7 +21,7 @@
 
 	<div class="mainContainer">
 		<!-- categoryList -->
-		<div id="categoryOuter">
+		<div id="categoryOuter" class="outer">
 			<h4>Category</h4>
 			<div class="categoryContainer">
 				<ul id="categoryList">
@@ -33,14 +33,14 @@
 		</div>
 
 		<!-- wordList -->
-		<div id="wordListOuter">
+		<div id="wordListOuter" class="outer">
 			<h4>Word</h4>
 			<div class="wordListContainer">
 			</div>
 		</div>
 
 		<!-- wordDetail -->
-		<div id="wordDetailOuter">
+		<div id="wordDetailOuter" class="outer">
 			<h4>Detail</h4>
 			<div class="wordDetailContainer" th:attr="data-wordbook-id=${wordbookId}">
 				<div class="message" th:if="${regist_ok} != null" th:text="${regist_ok}"></div>
@@ -57,12 +57,14 @@
 	<div id="modalOuter" class="hidden">
 		<div id="deleteConfirmModal" class="">
 			<p>本当に削除しますか？</p>
-			<button id="deleteOk">はい</button>
-			<button id="deleteNg">いいえ</button>
+			<div id="btnContainer">
+				<button id="deleteOk">はい</button>
+				<button id="deleteNg">いいえ</button>
+			</div>
 		</div>
 		<div id="deletedMsgModal" class="hidden">
 			<p id="deletedMsg"></p>
-			<button id="closeModalBtn">閉じる</button>		
+			<button id="closeModalBtn">閉じる</button>
 		</div>
 	</div>
 </body>

--- a/KnowledgeMap/src/main/resources/templates/wordbook_list.html
+++ b/KnowledgeMap/src/main/resources/templates/wordbook_list.html
@@ -28,7 +28,7 @@
 		<button type="submit" id="registBtn">追加する</button>
 	</form>
 	<!-- 単語帳リスト -->
-	<div id="wordbookListContainer">
+	<div id="wordbookListContainer" class="outer">
 
 		<ul class="wordbookList">
 			<li th:each="wordbook : ${wordbookList}" th:object="${wordbook}">
@@ -48,8 +48,10 @@
 	<div id="modalOuter" class="hidden">
 		<div id="deleteConfirmModal" class="">
 			<p>本当に削除しますか？</p>
-			<button id="deleteOk">はい</button>
-			<button id="deleteNg">いいえ</button>
+			<div id="btnContainer">
+				<button id="deleteOk">はい</button>
+				<button id="deleteNg">いいえ</button>
+			</div>
 		</div>
 		<div id="deletedMsgModal" class="hidden">
 			<p id="deletedMsg"></p>

--- a/KnowledgeMap/src/main/resources/templates/wordbook_list.html
+++ b/KnowledgeMap/src/main/resources/templates/wordbook_list.html
@@ -7,7 +7,7 @@
 	<link rel="stylesheet" th:href="@{/css/common.css}">
 	<link rel="stylesheet" th:href="@{/css/wordbook_list.css}">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
-	<script th:src="@{/js/wordbook_list.js}" defer></script>
+	<script type="module" th:src="@{/js/wordbook_list.js}" defer></script>
 </head>
 
 <body>
@@ -42,15 +42,19 @@
 		</ul>
 
 	</div>
-	<a th:href="@{/login}" id="return" class="button">ログアウトする</a>
 	<!-- 背景オーバーレイ -->
-	<div id="modalOverlay" class="modalOverlayHidden"></div>
-
-	<!-- モーダル本体 -->
-	<div id="deleteConfirmModal" class="modalHidden">
-		<p>本当に削除しますか？</p>
-		<button id="deleteOk">はい</button>
-		<button id="deleteNg">いいえ</button>
+	<div id="modalOverlay" class="hidden"></div>
+	<!-- 削除確認モーダル -->
+	<div id="modalOuter" class="hidden">
+		<div id="deleteConfirmModal" class="">
+			<p>本当に削除しますか？</p>
+			<button id="deleteOk">はい</button>
+			<button id="deleteNg">いいえ</button>
+		</div>
+		<div id="deletedMsgModal" class="hidden">
+			<p id="deletedMsg"></p>
+			<button id="closeModalBtn">閉じる</button>		
+		</div>
 	</div>
 
 </body>


### PR DESCRIPTION
####単語帳・単語・カテゴリ削除後に処理結果メッセージを表示するように変更
- 削除確認モーダルで「はい」をクリックして削除を実行すると、
モーダルの中身が処理結果メッセージに切り替わる

- モーダルの表示関数を共通化し、コードの重複を排除

- モーダルの左右の表示位置と幅の基準を、削除対象が属する親のリスト要素に変更



